### PR TITLE
make it be spot instances

### DIFF
--- a/gitlabcluster.yml
+++ b/gitlabcluster.yml
@@ -12,6 +12,7 @@ managedNodeGroups:
     volumeSize: 100
     ssh:
       enableSsm: true
+    spot: true
 
 cloudWatch:
   clusterLogging:


### PR DESCRIPTION
For the initial POC, we should use spot instances.  When we do this for real, we will use terraform, and probably won't be using spot instances.