### PR TITLE
Get RDS going with gitlab

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,6 @@ you change it back to master before you make your PR.
 
 `aws-vault exec sandbox-admin -- ./destroy.sh gitlab-dev`
 
-If it asks you for oidc stuff, just give it random stuff.
-That will go away once we go back to a single tf run.
-
 Also, some namespaces won't delete right off.  You will need to
 follow the procedure in here to make them actually go away:
 https://craignewtondev.medium.com/how-to-fix-kubernetes-namespace-deleting-stuck-in-terminating-state-5ed75792647e

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ and dynamodb stuff for remote state and locking and then goes on to do the deplo
 Run it like: `aws-vault exec sandbox-admin -- ./setup.sh gitlab-dev` where
 `gitlab-dev` is the name of your cluster.
 
+NOTE:  Right now, you must run this in the account that is hosting the live
+route53 domain that this uses.  Otherwise, it will write it's DNS entries into
+the other account's route53, and nothing will ever see them.
+
 ## Deploy
 
 `aws-vault exec sandbox-admin -- ./deploy.sh gitlab-dev` will deploy all the

--- a/README.md
+++ b/README.md
@@ -121,5 +121,12 @@ and it worked, so that might be a useful tool.
 `helm history gitlab -n gitlab --debug` might also be a good tool
 to see how the rollout went.
 
+### Dashboard
+
+If you want to see what is going on in the cluster, and you are a k8s-admin,
+you can do `kubectl port-forward service/dashboard-kubernetes-dashboard 4430:443 -n kubernetes-dashboard`
+and then go to http://localhost:4430/ to see almost everything.  It is running in a
+read-only mode, with reduced privs, so it can't see things like secrets and so on.
+
 
 Have fun!!

--- a/clusters/gitlab-cluster/cluster-autoscaler/autoscaler.yaml
+++ b/clusters/gitlab-cluster/cluster-autoscaler/autoscaler.yaml
@@ -27,10 +27,10 @@ spec:
       interval: 1m
   values:
     extraArgs:
-      skip-nodes-with-system-pods: false
-      balance-similar-node-groups: true
+      skip-nodes-with-system-pods: "false"
+      balance-similar-node-groups: "true"
     podAnnotations:
-      cluster-autoscaler.kubernetes.io/safe-to-evict: false
+      cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
   valuesFrom:
     - kind: ConfigMap
       name: terraform-info

--- a/clusters/gitlab-cluster/cluster-autoscaler/autoscaler.yaml
+++ b/clusters/gitlab-cluster/cluster-autoscaler/autoscaler.yaml
@@ -37,3 +37,7 @@ spec:
       name: terraform-info
       valuesKey: cluster_name
       targetPath: autoDiscovery.clusterName
+    - kind: ConfigMap
+      name: terraform-info
+      valuesKey: autoscalerRoleAnnotations
+      targetPath: rbac.serviceAccount.annotations

--- a/clusters/gitlab-cluster/cluster-autoscaler/autoscaler.yaml
+++ b/clusters/gitlab-cluster/cluster-autoscaler/autoscaler.yaml
@@ -27,7 +27,10 @@ spec:
       interval: 1m
   values:
     extraArgs:
-      skip-nodes-with-system-pods: true
+      skip-nodes-with-system-pods: false
+      balance-similar-node-groups: true
+    podAnnotations:
+      cluster-autoscaler.kubernetes.io/safe-to-evict: false
   valuesFrom:
     - kind: ConfigMap
       name: terraform-info

--- a/clusters/gitlab-cluster/cluster-autoscaler/autoscaler.yaml
+++ b/clusters/gitlab-cluster/cluster-autoscaler/autoscaler.yaml
@@ -39,5 +39,5 @@ spec:
       targetPath: autoDiscovery.clusterName
     - kind: ConfigMap
       name: terraform-info
-      valuesKey: autoscalerRoleAnnotations
-      targetPath: rbac.serviceAccount.annotations
+      valuesKey: autoscalerRoleArn
+      targetPath: rbac.serviceAccount.annotations.eks\.amazonaws\.com/role-arn

--- a/clusters/gitlab-cluster/dashboard/README.md
+++ b/clusters/gitlab-cluster/dashboard/README.md
@@ -1,0 +1,9 @@
+# Dashboard
+
+This sets up https://github.com/kubernetes/dashboard .
+
+To access it, do this:
+```
+kubectl port-forward service/dashboard-kubernetes-dashboard 4430:443 -n kubernetes-dashboard
+```
+and then go to http://localhost:4430/

--- a/clusters/gitlab-cluster/dashboard/dashboard.yaml
+++ b/clusters/gitlab-cluster/dashboard/dashboard.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kubernetes-dashboard
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: kubernetes-dashboard
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: https://kubernetes.github.io/dashboard/
+
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: dashboard
+  namespace: kubernetes-dashboard
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: dashboard
+      version: "4.0.3"
+      sourceRef:
+        kind: HelmRepository
+        name: kubernetes-dashboard
+        namespace: flux-system
+      interval: 1m
+  values:
+    protocolHttp: true
+    rbac:
+      clusterReadOnlyRole: true

--- a/clusters/gitlab-cluster/dashboard/dashboard.yaml
+++ b/clusters/gitlab-cluster/dashboard/dashboard.yaml
@@ -33,7 +33,7 @@ spec:
       interval: 1m
   values:
     protocolHttp: true
-    rbac:
-      clusterReadOnlyRole: true
+    # rbac:
+    #   clusterReadOnlyRole: true
     metrics-server:
       enabled: true

--- a/clusters/gitlab-cluster/dashboard/dashboard.yaml
+++ b/clusters/gitlab-cluster/dashboard/dashboard.yaml
@@ -35,3 +35,5 @@ spec:
     protocolHttp: true
     rbac:
       clusterReadOnlyRole: true
+    metricsScraper:
+      enabled: true

--- a/clusters/gitlab-cluster/dashboard/dashboard.yaml
+++ b/clusters/gitlab-cluster/dashboard/dashboard.yaml
@@ -35,3 +35,5 @@ spec:
     protocolHttp: true
     rbac:
       clusterReadOnlyRole: true
+    metrics-server:
+      enabled: true

--- a/clusters/gitlab-cluster/dashboard/dashboard.yaml
+++ b/clusters/gitlab-cluster/dashboard/dashboard.yaml
@@ -24,7 +24,7 @@ spec:
   interval: 5m
   chart:
     spec:
-      chart: dashboard
+      chart: kubernetes-dashboard
       version: "4.0.3"
       sourceRef:
         kind: HelmRepository

--- a/clusters/gitlab-cluster/dashboard/dashboard.yaml
+++ b/clusters/gitlab-cluster/dashboard/dashboard.yaml
@@ -35,5 +35,5 @@ spec:
     protocolHttp: true
     # rbac:
     #   clusterReadOnlyRole: true
-    metrics-server:
-      enabled: true
+    # metrics-server:
+    #   enabled: true

--- a/clusters/gitlab-cluster/dashboard/dashboard.yaml
+++ b/clusters/gitlab-cluster/dashboard/dashboard.yaml
@@ -33,7 +33,5 @@ spec:
       interval: 1m
   values:
     protocolHttp: true
-    # rbac:
-    #   clusterReadOnlyRole: true
-    # metrics-server:
-    #   enabled: true
+    rbac:
+      clusterReadOnlyRole: true

--- a/clusters/gitlab-cluster/dashboard/kustomization.yaml
+++ b/clusters/gitlab-cluster/dashboard/kustomization.yaml
@@ -1,4 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- gitlab.yaml
+- dashboard.yaml
+

--- a/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
+++ b/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: tspencer/tfrestructure
+    branch: tspencer/rdsgitlab
   secretRef:
     name: flux-system
   url: https://github.com/18F/identity-gitlab

--- a/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
+++ b/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: tspencer/rdsgitlab
+    branch: main
   secretRef:
     name: flux-system
   url: https://github.com/18F/identity-gitlab

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -48,3 +48,11 @@ spec:
       name: terraform-gitlab-info
       valuesKey: certmanager-issuer-email
       targetPath: certmanager-issuer.email
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: pghost
+      targetPath: global.psql.host
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: pgport
+      targetPath: global.psql.port

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -29,6 +29,12 @@ spec:
     global:
       ingress:
         enabled: true
+      psql:
+        password:
+          secret: rds-pw-gitlab
+          key: password
+    postgresql:
+      install: false
   valuesFrom:
     - kind: ConfigMap
       name: terraform-gitlab-info

--- a/clusters/gitlab-cluster/kustomization.yaml
+++ b/clusters/gitlab-cluster/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - ./logging/
 - ./cluster-autoscaler/
 - ./aws-node-termination-handler/
-- ./secrets-store-csi/
+# - ./secrets-store-csi/
 - ./metrics-server/
 - ./dashboard/
 - ./podinfo/

--- a/clusters/gitlab-cluster/kustomization.yaml
+++ b/clusters/gitlab-cluster/kustomization.yaml
@@ -8,6 +8,6 @@ resources:
 - ./cluster-autoscaler/
 - ./aws-node-termination-handler/
 - ./secrets-store-csi/
-- ./metrics-server/
+# - ./metrics-server/
 - ./dashboard/
 - ./podinfo/

--- a/clusters/gitlab-cluster/kustomization.yaml
+++ b/clusters/gitlab-cluster/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 - ./logging/
 - ./cluster-autoscaler/
 - ./aws-node-termination-handler/
+- ./secrets-store-csi/

--- a/clusters/gitlab-cluster/kustomization.yaml
+++ b/clusters/gitlab-cluster/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
 - ./cluster-autoscaler/
 - ./aws-node-termination-handler/
 - ./secrets-store-csi/
+- ./metrics-server/

--- a/clusters/gitlab-cluster/kustomization.yaml
+++ b/clusters/gitlab-cluster/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
 - ./aws-node-termination-handler/
 - ./secrets-store-csi/
 - ./metrics-server/
+- ./dashboard/

--- a/clusters/gitlab-cluster/kustomization.yaml
+++ b/clusters/gitlab-cluster/kustomization.yaml
@@ -8,6 +8,6 @@ resources:
 - ./cluster-autoscaler/
 - ./aws-node-termination-handler/
 - ./secrets-store-csi/
-# - ./metrics-server/
+- ./metrics-server/
 - ./dashboard/
 - ./podinfo/

--- a/clusters/gitlab-cluster/kustomization.yaml
+++ b/clusters/gitlab-cluster/kustomization.yaml
@@ -10,4 +10,3 @@ resources:
 # - ./secrets-store-csi/
 - ./metrics-server/
 - ./dashboard/
-- ./podinfo/

--- a/clusters/gitlab-cluster/kustomization.yaml
+++ b/clusters/gitlab-cluster/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
 - ./secrets-store-csi/
 - ./metrics-server/
 - ./dashboard/
+- ./podinfo/

--- a/clusters/gitlab-cluster/metrics-server/README.md
+++ b/clusters/gitlab-cluster/metrics-server/README.md
@@ -2,4 +2,5 @@
 
 This gets metrics so we can do stuff like `kubectl top`.
 
-https://github.com/bitnami/charts/tree/master/bitnami/metrics-server
+https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html
+

--- a/clusters/gitlab-cluster/metrics-server/README.md
+++ b/clusters/gitlab-cluster/metrics-server/README.md
@@ -1,0 +1,5 @@
+# Metrics Server
+
+This gets metrics so we can do stuff like `kubectl top`.
+
+https://github.com/bitnami/charts/tree/master/bitnami/metrics-server

--- a/clusters/gitlab-cluster/metrics-server/kustomization.yaml
+++ b/clusters/gitlab-cluster/metrics-server/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- metrics-server.yaml

--- a/clusters/gitlab-cluster/metrics-server/metrics-server.yaml
+++ b/clusters/gitlab-cluster/metrics-server/metrics-server.yaml
@@ -1,10 +1,4 @@
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: metrics-server
-
----
 apiVersion: source.toolkit.fluxcd.io/v1beta1
 kind: HelmRepository
 metadata:
@@ -19,7 +13,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: metrics
-  namespace: metrics-server
+  namespace: kube-system
 spec:
   interval: 5m
   chart:

--- a/clusters/gitlab-cluster/metrics-server/metrics-server.yaml
+++ b/clusters/gitlab-cluster/metrics-server/metrics-server.yaml
@@ -1,27 +1,186 @@
----
-apiVersion: source.toolkit.fluxcd.io/v1beta1
-kind: HelmRepository
+apiVersion: v1
+kind: ServiceAccount
 metadata:
-  name: bitnami
-  namespace: flux-system
-spec:
-  interval: 1m
-  url: https://charts.bitnami.com/bitnami
-
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
-kind: HelmRelease
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
 metadata:
-  name: metrics
+  labels:
+    k8s-app: metrics-server
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+  name: system:aggregated-metrics-reader
+rules:
+- apiGroups:
+  - metrics.k8s.io
+  resources:
+  - pods
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - nodes
+  - nodes/stats
+  - namespaces
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: system:metrics-server
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
   namespace: kube-system
 spec:
-  interval: 5m
-  chart:
+  ports:
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: https
+  selector:
+    k8s-app: metrics-server
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: metrics-server
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: metrics-server
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        k8s-app: metrics-server
     spec:
-      chart: metrics-server
-      version: "5.8.7"
-      sourceRef:
-        kind: HelmRepository
-        name: bitnami
-        namespace: flux-system
-      interval: 1m
+      containers:
+      - args:
+        - --cert-dir=/tmp
+        - --secure-port=4443
+        - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
+        - --kubelet-use-node-status-port
+        image: k8s.gcr.io/metrics-server/metrics-server:v0.4.4
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /livez
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+        name: metrics-server
+        ports:
+        - containerPort: 4443
+          name: https
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: https
+            scheme: HTTPS
+          periodSeconds: 10
+        securityContext:
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp-dir
+      nodeSelector:
+        kubernetes.io/os: linux
+      priorityClassName: system-cluster-critical
+      serviceAccountName: metrics-server
+      volumes:
+      - emptyDir: {}
+        name: tmp-dir
+---
+apiVersion: apiregistration.k8s.io/v1
+kind: APIService
+metadata:
+  labels:
+    k8s-app: metrics-server
+  name: v1beta1.metrics.k8s.io
+spec:
+  group: metrics.k8s.io
+  groupPriorityMinimum: 100
+  insecureSkipTLSVerify: true
+  service:
+    name: metrics-server
+    namespace: kube-system
+  version: v1beta1
+  versionPriority: 100

--- a/clusters/gitlab-cluster/metrics-server/metrics-server.yaml
+++ b/clusters/gitlab-cluster/metrics-server/metrics-server.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metrics-server
+
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: bitnami
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: https://charts.bitnami.com/bitnami
+
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: metrics
+  namespace: metrics-server
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: metrics-server
+      version: "5.8.7"
+      sourceRef:
+        kind: HelmRepository
+        name: bitnami
+        namespace: flux-system
+      interval: 1m

--- a/clusters/gitlab-cluster/metrics-server/update.sh
+++ b/clusters/gitlab-cluster/metrics-server/update.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+#
+# from https://docs.aws.amazon.com/eks/latest/userguide/metrics-server.html
+#
+
+curl -L https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml > metrics-server.yaml
+

--- a/clusters/gitlab-cluster/secrets-store-csi/README.md
+++ b/clusters/gitlab-cluster/secrets-store-csi/README.md
@@ -1,0 +1,5 @@
+# Secrets Store CSI
+
+This lets us store secrets in AWS Secrets Manager.
+
+This comes from https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_csi_driver.html

--- a/clusters/gitlab-cluster/secrets-store-csi/aws-provider-installer.yaml
+++ b/clusters/gitlab-cluster/secrets-store-csi/aws-provider-installer.yaml
@@ -1,0 +1,85 @@
+# https://kubernetes.io/docs/reference/access-authn-authz/rbac
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-aws
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-secrets-store-provider-aws-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-secrets-store-provider-aws-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-secrets-store-provider-aws-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: csi-secrets-store-provider-aws
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: kube-system
+  name: csi-secrets-store-provider-aws
+  labels:
+    app: csi-secrets-store-provider-aws
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-aws
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-aws
+    spec:
+      serviceAccountName: csi-secrets-store-provider-aws
+      hostNetwork: true
+      containers:
+        - name: provider-aws-installer
+          image: public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws:latest
+          imagePullPolicy: Always
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: HostToContainer
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "/etc/kubernetes/secrets-store-csi-providers"
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: linux

--- a/clusters/gitlab-cluster/secrets-store-csi/kustomization.yaml
+++ b/clusters/gitlab-cluster/secrets-store-csi/kustomization.yaml
@@ -1,5 +1,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- logging.yaml
+- secrets-store-csi.yaml
 - aws-provider-installer.yaml

--- a/clusters/gitlab-cluster/secrets-store-csi/kustomization.yaml
+++ b/clusters/gitlab-cluster/secrets-store-csi/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- logging.yaml
+- aws-provider-installer.yaml

--- a/clusters/gitlab-cluster/secrets-store-csi/secrets-store-csi.yaml
+++ b/clusters/gitlab-cluster/secrets-store-csi/secrets-store-csi.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1beta1
+kind: HelmRepository
+metadata:
+  name: secrets-store-csi-driver
+  namespace: flux-system
+spec:
+  interval: 1m
+  url: https://raw.githubusercontent.com/kubernetes-sigs/secrets-store-csi-driver/master/charts
+
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: csi-secrets-store
+  namespace: kube-system
+spec:
+  interval: 5m
+  chart:
+    spec:
+      chart: secrets-store-csi-driver
+      version: "0.0.21"
+      sourceRef:
+        kind: HelmRepository
+        name: secrets-store-csi-driver
+        namespace: flux-system
+      interval: 1m
+  values:
+    grpcSupportedProviders: aws

--- a/terraform/aws-load-balancer-controller.tf
+++ b/terraform/aws-load-balancer-controller.tf
@@ -245,8 +245,8 @@ resource "kubernetes_config_map" "terraform-info" {
   }
 
   data = {
-    "cluster_name" = var.cluster_name,
-    "region"       = var.region,
-    "autoscalerRoleAnnotations" = "[eks.amazonaws.com/role-arn: ${aws_iam_role.cluster-autoscaler.arn}]"
+    "cluster_name"      = var.cluster_name,
+    "region"            = var.region,
+    "autoscalerRoleArn" = aws_iam_role.cluster-autoscaler.arn
   }
 }

--- a/terraform/aws-load-balancer-controller.tf
+++ b/terraform/aws-load-balancer-controller.tf
@@ -246,6 +246,7 @@ resource "kubernetes_config_map" "terraform-info" {
 
   data = {
     "cluster_name" = var.cluster_name,
-    "region"       = var.region
+    "region"       = var.region,
+    "autoscalerRoleAnnotations" = "[eks.amazonaws.com/role-arn: ${aws_iam_role.cluster-autoscaler.arn}]"
   }
 }

--- a/terraform/cluster-autoscaler.tf
+++ b/terraform/cluster-autoscaler.tf
@@ -30,29 +30,34 @@ resource "aws_iam_role_policy" "cluster-autoscaler" {
 
   policy = <<EOF
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeAutoScalingInstances",
-                "autoscaling:DescribeLaunchConfigurations",
-                "autoscaling:SetDesiredCapacity",
-                "autoscaling:TerminateInstanceInAutoScalingGroup",
-                "autoscaling:DescribeTags",
-                "autoscaling:DescribeLaunchConfigurations",
-                "ec2:DescribeLaunchTemplateVersions"
-            ],
-            "Resource": ["*"],
-            "Condition": {
-              "StringEquals": {
-                "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled": "true",
-                "autoscaling:ResourceTag/kubernetes.io/cluster/${var.cluster_name}": "owned"
-              }
-            }
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:SetDesiredCapacity",
+        "autoscaling:TerminateInstanceInAutoScalingGroup"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled": "true",
+          "autoscaling:ResourceTag/kubernetes.io/cluster/${var.cluster_name}": "owned"
         }
-    ]
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeAutoScalingInstances",
+        "autoscaling:DescribeTags",
+        "autoscaling:DescribeLaunchConfigurations",
+        "ec2:DescribeLaunchTemplateVersions"
+      ],
+      "Resource": "*"
+    }
+  ]
 }
 EOF
 }

--- a/terraform/cluster-autoscaler.tf
+++ b/terraform/cluster-autoscaler.tf
@@ -1,0 +1,58 @@
+# set things up for the serviceaccount to have proper perms so it can scale stuff.
+resource "aws_iam_role" "cluster-autoscaler" {
+  name               = "${var.cluster_name}-cluster-autoscaler"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${aws_iam_openid_connect_provider.eks.arn}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "ForAnyValue:StringEquals": {
+          "${aws_iam_openid_connect_provider.eks.url}:sub": [
+            "system:serviceaccount:kube-system:eksclusterautoscaler-aws-cluster-autoscaler"
+          ]
+        }
+      }
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy" "cluster-autoscaler" {
+  name = "${var.cluster_name}-cluster-autoscaler-policy"
+  role = aws_iam_role.cluster-autoscaler.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:DescribeAutoScalingInstances",
+                "autoscaling:DescribeLaunchConfigurations",
+                "autoscaling:SetDesiredCapacity",
+                "autoscaling:TerminateInstanceInAutoScalingGroup",
+                "autoscaling:DescribeTags",
+                "autoscaling:DescribeLaunchConfigurations",
+                "ec2:DescribeLaunchTemplateVersions"
+            ],
+            "Resource": ["*"],
+            "Condition": {
+              "StringEquals": {
+                "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled": "true",
+                "autoscaling:ResourceTag/kubernetes.io/cluster/${var.cluster_name}": "owned"
+              }
+            }
+        }
+    ]
+}
+EOF
+}

--- a/terraform/eks-cluster.tf
+++ b/terraform/eks-cluster.tf
@@ -91,7 +91,7 @@ resource "aws_security_group" "eks-cluster" {
   }
 
   tags = {
-    Name = "terraform-eks"
+    Name = "${var.cluster_name}-eks-cluster"
   }
 }
 
@@ -103,4 +103,14 @@ resource "aws_security_group_rule" "eks-cluster-ingress-workstation-https" {
   security_group_id = aws_security_group.eks-cluster.id
   to_port           = 443
   type              = "ingress"
+}
+
+resource "aws_security_group_rule" "eks-cluster-egress-db" {
+  source_security_group_id = aws_security_group.gitlab-db.id
+  description              = "Allow eks to talk to databases"
+  from_port                = 5432
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks-cluster.id
+  to_port                  = 5432
+  type                     = "egress"
 }

--- a/terraform/eks-cluster.tf
+++ b/terraform/eks-cluster.tf
@@ -94,13 +94,3 @@ resource "aws_security_group" "eks-cluster" {
     Name = "${var.cluster_name}-eks-cluster"
   }
 }
-
-resource "aws_security_group_rule" "eks-cluster-ingress-workstation-https" {
-  cidr_blocks       = var.kubecontrolnets
-  description       = "Allow workstation to communicate with everything"
-  from_port         = 443
-  protocol          = "tcp"
-  security_group_id = aws_security_group.eks-cluster.id
-  to_port           = 443
-  type              = "ingress"
-}

--- a/terraform/eks-cluster.tf
+++ b/terraform/eks-cluster.tf
@@ -104,13 +104,3 @@ resource "aws_security_group_rule" "eks-cluster-ingress-workstation-https" {
   to_port           = 443
   type              = "ingress"
 }
-
-resource "aws_security_group_rule" "eks-cluster-egress-db" {
-  source_security_group_id = aws_security_group.gitlab-db.id
-  description              = "Allow eks to talk to databases"
-  from_port                = 5432
-  protocol                 = "tcp"
-  security_group_id        = aws_security_group.eks-cluster.id
-  to_port                  = 5432
-  type                     = "egress"
-}

--- a/terraform/eks-worker-nodes.tf
+++ b/terraform/eks-worker-nodes.tf
@@ -122,21 +122,6 @@ resource "aws_iam_role_policy" "worker_nodes" {
         "logs:PutLogEvents"
       ],
       "Resource": "*"
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "autoscaling:SetDesiredCapacity",
-        "autoscaling:TerminateInstanceInAutoScalingGroup",
-        "autoscaling:UpdateAutoScalingGroup"
-      ],
-      "Resource": "*",
-      "Condition": {
-        "StringEquals": {
-          "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled": "true",
-          "autoscaling:ResourceTag/kubernetes.io/cluster/${var.cluster_name}": "owned"
-        }
-      }
     }
   ]
 }

--- a/terraform/eks-worker-nodes.tf
+++ b/terraform/eks-worker-nodes.tf
@@ -12,7 +12,7 @@ resource "aws_eks_node_group" "eks" {
   capacity_type   = var.nodetype
 
   # if the cluster autoscaler grew us, don't mess with it
-  lifecycle{
+  lifecycle {
     ignore_changes = [scaling_config.0.desired_size]
   }
 

--- a/terraform/eks-worker-nodes.tf
+++ b/terraform/eks-worker-nodes.tf
@@ -11,6 +11,11 @@ resource "aws_eks_node_group" "eks" {
   instance_types  = [var.node_instance_type]
   capacity_type   = var.nodetype
 
+  # if the cluster autoscaler grew us, don't mess with it
+  lifecycle{
+    ignore_changes = [scaling_config.0.desired_size]
+  }
+
   scaling_config {
     desired_size = 3
     max_size     = var.node_max_size
@@ -116,6 +121,7 @@ resource "aws_iam_role_policy" "worker_nodes" {
         "autoscaling:DescribeAutoScalingInstances",
         "autoscaling:DescribeLaunchConfigurations",
         "autoscaling:DescribeTags",
+        "autoscaling:SetDesiredCapacity",
         "ec2:DescribeLaunchTemplateVersions",
         "logs:CreateLogGroup",
         "logs:CreateLogStream",

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -19,3 +19,94 @@ resource "kubernetes_config_map" "terraform-gitlab-info" {
     "certmanager-issuer-email" = var.certmanager-issuer
   }
 }
+
+# This is actually created by the deploy script so that
+# it is available when we do tf, but not stored in the state.
+data "aws_secretsmanager_secret_version" "rds-pw-gitlab" {
+  secret_id = "${var.cluster_name}-rds-pw-gitlab"
+}
+
+resource "kubernetes_secret" "rds-pw-gitlab" {
+  depends_on = [kubernetes_namespace.teleport]
+  metadata {
+    name      = "rds-pw-gitlab"
+    namespace = "gitlab"
+  }
+
+  data = {
+    password = data.aws_secretsmanager_secret_version.rds-pw-gitlab.secret_string
+  }
+}
+
+resource "aws_db_subnet_group" "gitlab" {
+  description = "${var.cluster_name} subnet group for gitlab"
+  name        = "${var.cluster_name}-db-gitlab"
+  subnet_ids  = aws_subnet.db.*.id
+
+  tags = {
+    Name = "${var.cluster_name}-db-gitlab"
+  }
+}
+
+resource "aws_db_instance" "gitlab" {
+  allocated_storage       = 8
+  max_allocated_storage   = 100
+  engine                  = "postgres"
+  engine_version          = "13.2"
+  instance_class          = "db.t3.large"
+  name                    = "gitlabhq_production"
+  username                = "gitlab"
+  password                = data.aws_secretsmanager_secret_version.rds-pw-gitlab.secret_string
+  parameter_group_name    = aws_db_parameter_group.force_ssl.id
+  skip_final_snapshot     = true
+  multi_az                = true
+  storage_encrypted       = true
+  backup_retention_period = var.rds_backup_retention_period
+  backup_window           = var.rds_backup_window
+  db_subnet_group_name    = aws_db_subnet_group.gitlab.id
+}
+
+resource "aws_db_parameter_group" "force_ssl" {
+  name_prefix = "gitlab"
+
+  # Before changing this value, make sure the parameters are correct for the
+  # version you are upgrading to.  See
+  # http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html.
+  family = "postgres13"
+
+  parameter {
+    name         = "rds.force_ssl"
+    value        = "1"
+    apply_method = "pending-reboot"
+  }
+
+  # Setting to 30 minutes, RDS requires value in ms
+  # https://aws.amazon.com/blogs/database/best-practices-for-amazon-rds-postgresql-replication/
+  parameter {
+    name  = "max_standby_archive_delay"
+    value = "1800000"
+  }
+
+  # Setting to 30 minutes, RDS requires value in ms
+  # https://aws.amazon.com/blogs/database/best-practices-for-amazon-rds-postgresql-replication/
+  parameter {
+    name  = "max_standby_streaming_delay"
+    value = "1800000"
+  }
+
+  # Log all Data Definition Layer changes (ALTER, CREATE, etc.)
+  parameter {
+    name  = "log_statement"
+    value = "ddl"
+  }
+
+  # Log all slow queries that take longer than specified time in ms
+  parameter {
+    name  = "log_min_duration_statement"
+    value = "250" # 250 ms
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -28,6 +28,15 @@ data "aws_secretsmanager_secret_version" "rds-pw-gitlab" {
   secret_id = "${var.cluster_name}-rds-pw-gitlab"
 }
 
+# XXX according to
+# https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1,
+# this is a good way to store secrets.  I am suspicious that there
+# is still stuff stored in the tf state that, even if encrypted, could
+# be dangerous.  If we want to go the extra mile, we can turn on the
+# secrets-store-csi and set up secret syncing so that there is no
+# suspicion of this, but that would add a fair amount of complexity that the gruntwork
+# article seems to say that we don't need to worry about, so for
+# now, we are going to go with their recommendation.
 resource "kubernetes_secret" "rds-pw-gitlab" {
   depends_on = [kubernetes_namespace.teleport]
   metadata {

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -50,7 +50,7 @@ resource "kubernetes_secret" "rds-pw-gitlab" {
 resource "aws_db_subnet_group" "gitlab" {
   description = "${var.cluster_name} subnet group for gitlab"
   name        = "${var.cluster_name}-db-gitlab"
-  subnet_ids  = aws_subnet.db.*.id
+  subnet_ids  = aws_subnet.service.*.id
 
   tags = {
     Name = "${var.cluster_name}-db-gitlab"
@@ -131,9 +131,9 @@ resource "aws_security_group" "gitlab-db" {
   vpc_id      = aws_vpc.eks.id
 
   ingress {
-    from_port   = 5432
-    to_port     = 5432
-    protocol    = "tcp"
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
     security_groups = [aws_security_group.eks-cluster.id]
   }
 

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -35,6 +35,13 @@ resource "kubernetes_secret" "rds-pw-gitlab" {
     namespace = "gitlab"
   }
 
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to labels, e.g. because helm adds stuff.
+      metadata.0.labels,
+    ]
+  }
+
   data = {
     password = data.aws_secretsmanager_secret_version.rds-pw-gitlab.secret_string
   }
@@ -67,6 +74,10 @@ resource "aws_db_instance" "gitlab" {
   backup_retention_period = var.rds_backup_retention_period
   backup_window           = var.rds_backup_window
   db_subnet_group_name    = aws_db_subnet_group.gitlab.id
+
+  tags = {
+    Name = "${var.cluster_name}-db-gitlab"
+  }
 }
 
 resource "aws_db_parameter_group" "force_ssl" {

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -134,7 +134,7 @@ resource "aws_security_group" "gitlab-db" {
     from_port       = 5432
     to_port         = 5432
     protocol        = "tcp"
-    security_groups = [aws_security_group.eks-cluster.id]
+    security_groups = [aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id]
   }
 
   tags = {

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -15,10 +15,6 @@ terraform {
     kubectl = {
       source = "gavinbunney/kubectl"
     }
-    flux = {
-      source  = "fluxcd/flux"
-      version = ">= 0.0.13"
-    }
     tls = {
       source  = "hashicorp/tls"
       version = "3.1.0"

--- a/terraform/teleport.tf
+++ b/terraform/teleport.tf
@@ -52,6 +52,15 @@ data "aws_secretsmanager_secret_version" "join-token" {
   secret_id = "${var.cluster_name}-teleport-join-token"
 }
 
+# XXX according to
+# https://blog.gruntwork.io/a-comprehensive-guide-to-managing-secrets-in-your-terraform-code-1d586955ace1,
+# this is a good way to store secrets.  I am suspicious that there
+# is still stuff stored in the tf state that, even if encrypted, could
+# be dangerous.  If we want to go the extra mile, we can turn on the
+# secrets-store-csi and set up secret syncing so that there is no
+# suspicion of this, but that would add a fair amount of complexity that the gruntwork
+# article seems to say that we don't need to worry about, so for
+# now, we are going to go with their recommendation.
 resource "kubernetes_secret" "teleport-kube-agent-join-token" {
   depends_on = [kubernetes_namespace.teleport]
   metadata {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,10 +17,20 @@ variable "vpc_cidr" {
   description = "cidr block for VPC"
 }
 
-# networks which are allowed to talk with the k8s API
+variable "eks_subnet_count" {
+  default     = 2
+  description = "number of subnets used for EKS"
+}
+
+variable "db_subnet_count" {
+  default     = 2
+  description = "number of subnets used for RDS"
+}
+
 variable "kubecontrolnets" {
   default = ["98.146.223.15/32", "159.142.0.0/16", "50.46.2.51/32"]
   type    = list(string)
+  description = "networks which are allowed to talk with the k8s API"
 }
 
 variable "nodetype" {
@@ -56,4 +66,12 @@ variable "domain" {
 variable "certmanager-issuer" {
   default = "security@login.gov"
   type    = string
+}
+
+variable "rds_backup_retention_period" {
+  default = "34"
+}
+
+variable "rds_backup_window" {
+  default = "08:00-08:34"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,7 +28,8 @@ variable "db_subnet_count" {
 }
 
 variable "kubecontrolnets" {
-  default = ["98.146.223.15/32", "159.142.0.0/16", "50.46.2.51/32"]
+  # set this up in your shell environment like this:
+  # export TF_VAR_kubecontrolnets='["x.x.x.x/32", "gsa.vpn.sub.net/16", "your.home.ip.addr/32"]'
   type    = list(string)
   description = "networks which are allowed to talk with the k8s API"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,15 +22,15 @@ variable "eks_subnet_count" {
   description = "number of subnets used for EKS"
 }
 
-variable "db_subnet_count" {
+variable "service_subnet_count" {
   default     = 2
-  description = "number of subnets used for RDS"
+  description = "number of subnets used for RDS and other services"
 }
 
 variable "kubecontrolnets" {
   # set this up in your shell environment like this:
   # export TF_VAR_kubecontrolnets='["x.x.x.x/32", "gsa.vpn.sub.net/16", "your.home.ip.addr/32"]'
-  type    = list(string)
+  type        = list(string)
   description = "networks which are allowed to talk with the k8s API"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,13 +27,6 @@ variable "service_subnet_count" {
   description = "number of subnets used for RDS and other services"
 }
 
-variable "kubecontrolnets" {
-  # set this up in your shell environment like this:
-  # export TF_VAR_kubecontrolnets='["x.x.x.x/32", "gsa.vpn.sub.net/16", "your.home.ip.addr/32"]'
-  type        = list(string)
-  description = "networks which are allowed to talk with the k8s API"
-}
-
 variable "nodetype" {
   default     = "SPOT"
   description = "make this be SPOT or ON_DEMAND"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,7 @@
 #
 
 variable "cluster_name" {
-  type = string
+  type        = string
   description = "name of the cluster that we are deploying this stuff to"
 }
 

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -16,7 +16,7 @@ resource "aws_vpc" "eks" {
 }
 
 resource "aws_subnet" "eks" {
-  count = 2
+  count = var.eks_subnet_count
 
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
@@ -29,6 +29,15 @@ resource "aws_subnet" "eks" {
     "kubernetes.io/role/elb", "1",
     "kubernetes.io/role/internal-elb", ""
   )
+}
+
+resource "aws_subnet" "db" {
+  count = var.db_subnet_count
+
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index + var.eks_subnet_count)
+  vpc_id                  = aws_vpc.eks.id
+  map_public_ip_on_launch = false
 }
 
 resource "aws_internet_gateway" "eks" {

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -15,29 +15,35 @@ resource "aws_vpc" "eks" {
   )
 }
 
-resource "aws_subnet" "eks" {
-  count = var.eks_subnet_count
+# have the db/service networks first because they probably won't grow
+resource "aws_subnet" "service" {
+  count = var.service_subnet_count
 
   availability_zone       = data.aws_availability_zones.available.names[count.index]
   cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
   vpc_id                  = aws_vpc.eks.id
+  map_public_ip_on_launch = false
+
+  tags = {
+    Name = "${var.cluster_name}-service-${count.index}"
+  }
+}
+
+# have the eks subnets come last so that we can add more later.
+resource "aws_subnet" "eks" {
+  count = var.eks_subnet_count
+
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  cidr_block              = cidrsubnet(var.vpc_cidr, 6, count.index + var.service_subnet_count)
+  vpc_id                  = aws_vpc.eks.id
   map_public_ip_on_launch = true
 
   tags = map(
-    "Name", "${var.cluster_name}-node",
+    "Name", "${var.cluster_name}-node-${count.index}",
     "kubernetes.io/cluster/${var.cluster_name}", "shared",
     "kubernetes.io/role/elb", "1",
     "kubernetes.io/role/internal-elb", ""
   )
-}
-
-resource "aws_subnet" "db" {
-  count = var.db_subnet_count
-
-  availability_zone       = data.aws_availability_zones.available.names[count.index]
-  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index + var.eks_subnet_count)
-  vpc_id                  = aws_vpc.eks.id
-  map_public_ip_on_launch = false
 }
 
 resource "aws_internet_gateway" "eks" {
@@ -54,6 +60,10 @@ resource "aws_route_table" "eks" {
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.eks.id
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-eks"
   }
 }
 


### PR DESCRIPTION
This gets gitlab going with RDS as it's backend instead of it's in-cluster PV based postgres.

It also:
* adds documentation on more things
* adds names on a lot of tf resources so they are easier to identify in the AWS console
* restructures the subnets so that they are bigger and we can add more node subnets without stepping on the service (db) network.  This will pretty much nuke any existing clusters, so expect to start over from scratch.
* Fixes the cluster autoscaler
* Gets the metrics-server and k8s dashboard going so we can look at what is going on more easily.
* Remove flux tf plugin since we do it another way
* Remove list of hardcoded IPs that we let into the k8s API so that people have to set it by hand.

Be aware that if you are upgrading to this from a previous version, the easiest thing might be to delete your cluster using the old code, git pull to this, and then deploy it again.  This change will basically delete everything and start over.

We have also identified a caveat with the DNS stuff.  You must deploy this in the account that is hosting the gitlab domain.  If you do it in another, it will write route53 CNAMEs out, but they'll never appear because that zone actually lives in the other account.
