### PR TITLE
fix gitlab-runner

### DIFF
--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -27,6 +27,12 @@ spec:
       interval: 1m
   values:
     global:
+      hosts:
+        https: false
+        gitlab:
+          name: gitlab-webservice-default
+          https: false
+          servicePort: 8181
       ingress:
         enabled: true
       psql:


### PR DESCRIPTION
gitlab-runner was giving out messages like `status=couldn't execute POST against https://gitlab.gitlab.identitysandbox.gov/api/v4/runners`, which was reasonable, because that name was unresolvable.  This change tells gitlab to use the internal service name to access the gitlab API instead of what it thinks is the hostname.

Since we use teleport to get into the gitlab UI, we don't need to set the external name to anything real.  If we do someday expose this, we may change this to a real hostname, but until then, this works fine.
