### PR TITLE
Create initial SES setup, pending verification

### DIFF
--- a/terraform/ses.tf
+++ b/terraform/ses.tf
@@ -38,7 +38,7 @@ resource "aws_ses_domain_dkim" "gitlab" {
   domain = aws_ses_domain_identity.gitlab.domain
 }
 
-resource "aws_route53_record" "example_amazonses_dkim_record" {
+resource "aws_route53_record" "gitlab_amazonses_dkim_record" {
   count   = 3
   zone_id = data.aws_route53_zone.gitlab.zone_id
   name    = "${element(aws_ses_domain_dkim.gitlab.dkim_tokens, count.index)}._domainkey"

--- a/terraform/ses.tf
+++ b/terraform/ses.tf
@@ -23,12 +23,12 @@ data "aws_iam_policy_document" "ses_email_user_policy" {
 }
 
 resource "aws_ses_domain_identity" "gitlab" {
-  domain = "gitlab.identitysandbox.com"
+  domain = "${var.cluster_name}.${var.domain}"
 }
 
 resource "aws_route53_record" "gitlab_amazonses_verification_record" {
   zone_id = data.aws_route53_zone.gitlab.zone_id
-  name    = "_amazonses.gitlab.identitysandbox.gov"
+  name    = "_amazonses.${var.cluster_name}.${var.domain}"
   type    = "TXT"
   ttl     = "600"
   records = [aws_ses_domain_identity.gitlab.verification_token]

--- a/terraform/ses.tf
+++ b/terraform/ses.tf
@@ -1,0 +1,63 @@
+resource "aws_iam_role_policy" "gitlab-ses-email" {
+  name   = "${var.cluster_name}-gitlab-ses-email"
+  role       = aws_iam_role.gitlab-ses.name
+  policy = data.aws_iam_policy_document.ses_email_role_policy.json
+}
+
+# XXX This is wrong, used as an example. Reviewer: what is right?
+resource "aws_iam_role" "gitlab-ses" {
+  name = "${var.cluster_name}-gitlab-ses-role"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+data "aws_iam_policy_document" "ses_email_role_policy" {
+  statement {
+    sid    = "AllowSendEmail"
+    effect = "Allow"
+    actions = [
+      "ses:SendRawEmail",
+      "ses:SendEmail",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_ses_domain_identity" "gitlab" {
+  domain = "gitlab.identitysandbox.com"
+}
+
+resource "aws_route53_record" "gitlab_amazonses_verification_record" {
+  zone_id = data.aws_route53_zone.gitlab.zone_id
+  name    = "_amazonses.gitlab.identitysandbox.gov"
+  type    = "TXT"
+  ttl     = "600"
+  records = [aws_ses_domain_identity.gitlab.verification_token]
+}
+
+resource "aws_ses_domain_dkim" "gitlab" {
+  domain = aws_ses_domain_identity.gitlab.domain
+}
+
+resource "aws_route53_record" "example_amazonses_dkim_record" {
+  count   = 3
+  zone_id = data.aws_route53_zone.gitlab.zone_id
+  name    = "${element(aws_ses_domain_dkim.gitlab.dkim_tokens, count.index)}._domainkey"
+  type    = "CNAME"
+  ttl     = "600"
+  records = ["${element(aws_ses_domain_dkim.gitlab.dkim_tokens, count.index)}.dkim.amazonses.com"]
+}

--- a/terraform/ses.tf
+++ b/terraform/ses.tf
@@ -1,29 +1,14 @@
-resource "aws_iam_role_policy" "gitlab-ses-email" {
-  name   = "${var.cluster_name}-gitlab-ses-email"
-  role       = aws_iam_role.gitlab-ses.name
-  policy = data.aws_iam_policy_document.ses_email_role_policy.json
+resource "aws_iam_user_policy" "gitlab-ses-email" {
+  name = "${var.cluster_name}-gitlab-ses-email"
+  user = aws_iam_user.gitlab-ses.name
+  policy = data.aws_iam_policy_document.ses_email_user_policy.json
 }
 
-# XXX This is wrong, used as an example. Reviewer: what is right?
-resource "aws_iam_role" "gitlab-ses" {
-  name = "${var.cluster_name}-gitlab-ses-role"
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "eks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
+resource "aws_iam_user" "gitlab-ses" {
+  name = "${var.cluster_name}-gitlab-ses"
 }
 
-data "aws_iam_policy_document" "ses_email_role_policy" {
+data "aws_iam_policy_document" "ses_email_user_policy" {
   statement {
     sid    = "AllowSendEmail"
     effect = "Allow"


### PR DESCRIPTION
Partially addresses https://github.com/18F/identity-devops/issues/3331

In a future PR, `aws_iam_user.gitlab-ses` will have a password that will be transformed into an SMTP key and provided to GitLab.

P.S. What's the style guidance on `-` vs `_`?