### PR TITLE
Allow git pull from our environments through VPC endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ to clone a repo on the gitlab server.
 #### Automated git-ssh
 
 The `gitlab-<clustername>.<domain>` endpoint should be plumbed up in the app environments
-if you have turned XXX on in tfvars, so things should be able to do a 
-`git clone git@gitlab-<clustername>.<domain>:root/repo.git` without hinderance.
+if you have turned `gitlab_enabled` on in tfvars, so things should be able to do a 
+`git clone git@gitlab:root/repo.git` without hinderance.  *NOTE:* you will need to use
+`gitlab` for the hostname instead of the proper `gitlab-<clustername>.<domain>` domain
+because you need to get to the privatelink instead of the real load balancer endpoint.
 
 #### Editing users/roles
 

--- a/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
+++ b/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: tspencer/vpcendpoints
+    branch: main
   secretRef:
     name: flux-system
   url: https://github.com/18F/identity-gitlab

--- a/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
+++ b/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: tspencer/vpcendpoints
   secretRef:
     name: flux-system
   url: https://github.com/18F/identity-gitlab

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -38,10 +38,6 @@ spec:
     global:
       hosts:
         https: false
-        gitlab:
-          name: gitlab-webservice-default
-          https: false
-          servicePort: 8181
       ingress:
         configureCertmanager: false
         tls:
@@ -69,6 +65,10 @@ spec:
       name: terraform-gitlab-info
       valuesKey: domain
       targetPath: global.hosts.domain
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: cluster_name
+      targetPath: global.hosts.hostSuffix
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: certmanager-issuer-email

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -77,3 +77,7 @@ spec:
       name: terraform-gitlab-info
       valuesKey: redishost
       targetPath: global.redis.host
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: ingress-security-groups
+      targetPath: nginx-ingress.controller.service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-security-groups

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -43,7 +43,7 @@ spec:
           # register with gitlab, but the ingress will still be named properly
           # because of the hostnameOverride below.
           name: gitlab-webservice-default
-           servicePort: 8181
+          servicePort: 8181
           https: false
       ingress:
         configureCertmanager: false

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -42,8 +42,9 @@ spec:
           # This is needed so that the runner will use the internal service to
           # register with gitlab, but the ingress will still be named properly
           # because of the hostnameOverride below.
-          serviceName: gitlab-webservice-default
-          servicePort: 8181
+          name: gitlab-webservice-default
+          # servicePort: 8181
+          servicePort: 80
           https: false
       ingress:
         configureCertmanager: false

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -38,6 +38,10 @@ spec:
     global:
       hosts:
         https: false
+        gitlab:
+          name: gitlab-webservice-default
+          https: false
+          servicePort: 8181
       ingress:
         configureCertmanager: false
         tls:
@@ -69,6 +73,10 @@ spec:
       name: terraform-gitlab-info
       valuesKey: cluster_name
       targetPath: global.hosts.hostSuffix
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: fullhostname
+      targetPath: global.hosts.gitlab.hostnameOverride
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: certmanager-issuer-email

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -38,18 +38,8 @@ spec:
     global:
       hosts:
         https: false
-        gitlab:
-          # This is needed so that the runner will use the internal service to
-          # register with gitlab, but the ingress will still be named properly
-          # because of the hostnameOverride below.
-          name: gitlab-webservice-default
-          servicePort: 8181
-          https: true
       ingress:
         configureCertmanager: false
-        tls:
-          enabled: false
-        enabled: true
       psql:
         password:
           secret: rds-pw-gitlab

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -26,12 +26,12 @@ spec:
         namespace: flux-system
       interval: 1m
   values:
-    nginx-ingress:
-      controller:
-        service:
-          annotations:
-            service.beta.kubernetes.io/aws-load-balancer-type: external
-            service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    # nginx-ingress:
+    #   controller:
+    #     service:
+    #       annotations:
+    #         service.beta.kubernetes.io/aws-load-balancer-type: external
+    #         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
     global:
       hosts:
         https: false
@@ -83,7 +83,7 @@ spec:
       name: terraform-gitlab-info
       valuesKey: redishost
       targetPath: global.redis.host
-    # - kind: ConfigMap
-    #   name: terraform-gitlab-info
-    #   valuesKey: ingress-security-groups
-    #   targetPath: nginx-ingress.controller.service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-security-groups
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: ingress-security-groups
+      targetPath: nginx-ingress.controller.service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-security-groups

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -26,12 +26,13 @@ spec:
         namespace: flux-system
       interval: 1m
   values:
-    # nginx-ingress:
-    #   controller:
-    #     service:
-    #       annotations:
-    #         service.beta.kubernetes.io/aws-load-balancer-type: external
-    #         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    nginx-ingress:
+      enabled: false
+      # controller:
+      #   service:
+      #     annotations:
+      #       service.beta.kubernetes.io/aws-load-balancer-type: external
+      #       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
     certmanager:
       install: false
     global:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -42,7 +42,7 @@ spec:
           # This is needed so that the runner will use the internal service to
           # register with gitlab, but the ingress will still be named properly
           # because of the hostnameOverride below.
-          name: gitlab-webservice-default
+          serviceName: gitlab-webservice-default
           servicePort: 8181
           https: false
       ingress:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -39,9 +39,11 @@ spec:
       hosts:
         https: false
         gitlab:
-          name: gitlab-webservice-default
+          # This is needed so that the runner will use the internal service to
+          # register with gitlab, but the ingress will still be named properly
+          # because of the hostnameOverride below.
+          name: gitlab-nginx-ingress-default-backend
           https: false
-          servicePort: 8181
       ingress:
         configureCertmanager: false
         tls:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -26,6 +26,12 @@ spec:
         namespace: flux-system
       interval: 1m
   values:
+    # nginx-ingress:
+    #   controller:
+    #     service:
+    #       annotations:
+    #         service.beta.kubernetes.io/aws-load-balancer-type: external
+    #         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
     global:
       hosts:
         https: false
@@ -77,7 +83,7 @@ spec:
       name: terraform-gitlab-info
       valuesKey: redishost
       targetPath: global.redis.host
-    - kind: ConfigMap
-      name: terraform-gitlab-info
-      valuesKey: ingress-security-groups
-      targetPath: nginx-ingress.controller.service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-security-groups
+    # - kind: ConfigMap
+    #   name: terraform-gitlab-info
+    #   valuesKey: ingress-security-groups
+    #   targetPath: nginx-ingress.controller.service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-security-groups

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -43,7 +43,6 @@ spec:
           # register with gitlab, but the ingress will still be named properly
           # because of the hostnameOverride below.
           name: gitlab-webservice-default
-           https: false
            servicePort: 8181
           https: false
       ingress:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -27,19 +27,64 @@ spec:
       interval: 1m
   values:
     nginx-ingress:
-      enabled: true
-      # controller:
-      #   service:
-      #     annotations:
-      #       service.beta.kubernetes.io/aws-load-balancer-type: external
-      #       service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+      controller:
+        scope:
+          enabled: true
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - gitlab-nginx
+                  - key: app.kubernetes.io/instance
+                    operator: In
+                    values:
+                    - gitlab-nginx
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                    - controller
+                topologyKey: kubernetes.io/hostname
+        service:
+          externalTrafficPolicy: Cluster
+          enableHttp: false
+          targetPorts:
+            https: http
+          annotations:
+            service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Name=gitlab-nginx,class=nginx,role=test,vpc=test
+            service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+            service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+            service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
+            service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+            service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+        config:
+          use-forwarded-headers: "true"
+          client-header-timeout: "420"
+          proxy-stream-timeout: "200s"
+          client-body-timeout: "420"
+        headers:
+          X-Forwarded-Ssl: "on"
+        stats:
+          enabled: true
+        metrics:
+          enabled: true
+      podSecurityPolicy:
+        enabled: true
+      serviceAccount:
+        create: true
     certmanager:
       install: false
     global:
-      hosts:
-        https: false
       ingress:
+        enabled: false
         configureCertmanager: false
+        tls:
+          enabled: false
       psql:
         password:
           secret: rds-pw-gitlab
@@ -94,3 +139,7 @@ spec:
       name: terraform-gitlab-info
       valuesKey: ingress-security-groups
       targetPath: nginx-ingress.controller.service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-security-groups
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: cert-arn
+      targetPath: nginx-ingress.controller.service.annotations.service\.beta\.kubernetes\.io/aws-load-balancer-ssl-cert

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -26,12 +26,12 @@ spec:
         namespace: flux-system
       interval: 1m
   values:
-    # nginx-ingress:
-    #   controller:
-    #     service:
-    #       annotations:
-    #         service.beta.kubernetes.io/aws-load-balancer-type: external
-    #         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    nginx-ingress:
+      controller:
+        service:
+          annotations:
+            service.beta.kubernetes.io/aws-load-balancer-type: external
+            service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
     global:
       hosts:
         https: false

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -19,7 +19,7 @@ spec:
   chart:
     spec:
       chart: gitlab
-      version: "4.11.3"
+      version: "4.11.4"
       sourceRef:
         kind: HelmRepository
         name: gitlab
@@ -43,9 +43,8 @@ spec:
           # register with gitlab, but the ingress will still be named properly
           # because of the hostnameOverride below.
           name: gitlab-webservice-default
-          # servicePort: 8181
-          servicePort: 80
-          https: false
+          servicePort: 8181
+          https: true
       ingress:
         configureCertmanager: false
         tls:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -42,7 +42,9 @@ spec:
           # This is needed so that the runner will use the internal service to
           # register with gitlab, but the ingress will still be named properly
           # because of the hostnameOverride below.
-          name: gitlab-nginx-ingress-default-backend
+          name: gitlab-webservice-default
+           https: false
+           servicePort: 8181
           https: false
       ingress:
         configureCertmanager: false

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -42,7 +42,7 @@ spec:
         configureCertmanager: false
         tls:
           enabled: false
-        enabled: false
+        enabled: true
       psql:
         password:
           secret: rds-pw-gitlab

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -32,6 +32,8 @@ spec:
     #       annotations:
     #         service.beta.kubernetes.io/aws-load-balancer-type: external
     #         service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: ip
+    certmanager:
+      install: false
     global:
       hosts:
         https: false
@@ -40,6 +42,9 @@ spec:
           https: false
           servicePort: 8181
       ingress:
+        configureCertmanager: false
+        tls:
+          enabled: false
         enabled: false
       psql:
         password:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -27,7 +27,7 @@ spec:
       interval: 1m
   values:
     nginx-ingress:
-      enabled: false
+      enabled: true
       # controller:
       #   service:
       #     annotations:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -34,7 +34,7 @@ spec:
           https: false
           servicePort: 8181
       ingress:
-        enabled: true
+        enabled: false
       psql:
         password:
           secret: rds-pw-gitlab

--- a/git-proxycommand.sh
+++ b/git-proxycommand.sh
@@ -20,7 +20,12 @@ cleanup() {
 }
 trap cleanup EXIT
 
-kubectl "$1" port-forward service/gitlab-gitlab-shell 2222:22 -n gitlab >/dev/null 2>&1 &
+if [ -z "$1" ] ; then
+	kubectl port-forward service/gitlab-gitlab-shell 2222:22 -n gitlab >/dev/null 2>&1 &
+else
+	kubectl "$1" port-forward service/gitlab-gitlab-shell 2222:22 -n gitlab >/dev/null 2>&1 &
+fi
+
 while ! nc -z localhost 2222 >/dev/null 2>&1 ; do
 	sleep 0.1
 done

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -224,11 +224,6 @@ resource "aws_security_group" "gitlab-redis" {
   }
 }
 
-data "aws_ip_ranges" "ec2" {
-  regions  = [var.region]
-  services = ["ec2"]
-}
-
 locals {
   nat_cidrs = formatlist("%s/32", aws_nat_gateway.nat.*.public_ip)
 }
@@ -237,17 +232,6 @@ resource "aws_security_group" "gitlab-ingress" {
   name        = "${var.cluster_name}-gitlab-ingress"
   description = "security group attached to gitlab ingress for ${var.cluster_name}"
   vpc_id      = aws_vpc.eks.id
-
-  # # allow ec2 hosts from our region in
-  # # XXX Eventually, once the networkfw gets put in, we will scrape the NAT gateways and put those in.
-  # # XXX OR we can remove this block entirely if privatelink works.
-  # ingress {
-  #   from_port        = 22
-  #   to_port          = 22
-  #   protocol         = "tcp"
-  #   cidr_blocks      = data.aws_ip_ranges.ec2.cidr_blocks
-  #   ipv6_cidr_blocks = data.aws_ip_ranges.ec2.ipv6_cidr_blocks
-  # }
 
   # allow kubernetes port-forward in to git-ssh
   ingress {

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -255,7 +255,7 @@ resource "aws_security_group" "gitlab-ingress" {
     from_port       = 22
     to_port         = 22
     protocol        = "tcp"
-    cidr_blocks     = [var.vpc_cidr]
+    security_groups = [aws_security_group.eks-cluster]
   }
 
   tags = {

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -332,11 +332,3 @@ resource "aws_vpc_endpoint_service" "gitlab" {
     Name = "gitlab-${var.cluster_name}.${var.domain}"
   }
 }
-
-# # This is an example of what you would need to plug into the environments
-# # to be able to talk to the gitlab service.
-# resource "aws_vpc_endpoint" "gitlab" {
-#   service_name      = "XXX from output.gitlab-privatelink-service_name"
-#   subnet_ids        = [aws_subnet.XXX.id]
-#   vpc_id            = aws_vpc.XXX.id
-# }

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -258,10 +258,10 @@ resource "aws_security_group" "gitlab-ingress" {
 
   # this allows the gitlab runners to register with gitlab
   ingress {
-    from_port       = 80
-    to_port         = 80
+    from_port       = 443
+    to_port         = 443
     protocol        = "tcp"
-    # security_groups = [aws_security_group.eks-cluster.id]
+    security_groups = [aws_security_group.eks-cluster.id, aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id]
     cidr_blocks     = local.nat_cidrs
   }
 

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -13,9 +13,9 @@ data "kubernetes_service" "gitlab-nginx-ingress-controller" {
   }
 }
 
-resource "aws_route53_record" "gitssh" {
+resource "aws_route53_record" "gitlab" {
   zone_id = data.aws_route53_zone.gitlab.zone_id
-  name    = "gitssh-${var.cluster_name}"
+  name    = "gitlab-${var.cluster_name}"
   type    = "CNAME"
   ttl     = "300"
   records = [data.kubernetes_service.gitlab-nginx-ingress-controller.status.0.load_balancer.0.ingress.0.hostname]
@@ -248,6 +248,14 @@ resource "aws_security_group" "gitlab-ingress" {
     to_port         = 22
     protocol        = "tcp"
     security_groups = [aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id]
+  }
+
+  # Allow the gitlab app to access itself over the ingress
+  ingress {
+    from_port       = 22
+    to_port         = 22
+    protocol        = "tcp"
+    cidr_blocks     = [var.vpc_cidr]
   }
 
   tags = {

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -238,15 +238,16 @@ resource "aws_security_group" "gitlab-ingress" {
   description = "security group attached to gitlab ingress for ${var.cluster_name}"
   vpc_id      = aws_vpc.eks.id
 
-  # allow ec2 hosts from our region in
-  # XXX eventually, once the networkfw gets put in, we will scrape the NAT gateways and put those in.
-  ingress {
-    from_port        = 22
-    to_port          = 22
-    protocol         = "tcp"
-    cidr_blocks      = data.aws_ip_ranges.ec2.cidr_blocks
-    ipv6_cidr_blocks = data.aws_ip_ranges.ec2.ipv6_cidr_blocks
-  }
+  # # allow ec2 hosts from our region in
+  # # XXX Eventually, once the networkfw gets put in, we will scrape the NAT gateways and put those in.
+  # # XXX OR we can remove this block entirely if privatelink works.
+  # ingress {
+  #   from_port        = 22
+  #   to_port          = 22
+  #   protocol         = "tcp"
+  #   cidr_blocks      = data.aws_ip_ranges.ec2.cidr_blocks
+  #   ipv6_cidr_blocks = data.aws_ip_ranges.ec2.ipv6_cidr_blocks
+  # }
 
   # allow kubernetes port-forward in to git-ssh
   ingress {
@@ -258,18 +259,18 @@ resource "aws_security_group" "gitlab-ingress" {
 
   # this allows the gitlab runners to register with gitlab
   ingress {
-    from_port       = 443
-    to_port         = 443
-    protocol        = "tcp"
-    cidr_blocks     = local.nat_cidrs
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = local.nat_cidrs
   }
 
   # this allows the gitlab runners to git pull
   ingress {
-    from_port       = 22
-    to_port         = 22
-    protocol        = "tcp"
-    cidr_blocks     = local.nat_cidrs
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = local.nat_cidrs
   }
 
   tags = {

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -261,7 +261,6 @@ resource "aws_security_group" "gitlab-ingress" {
     from_port       = 443
     to_port         = 443
     protocol        = "tcp"
-    security_groups = [aws_security_group.eks-cluster.id, aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id]
     cidr_blocks     = local.nat_cidrs
   }
 
@@ -300,27 +299,3 @@ resource "aws_acm_certificate_validation" "gitlab" {
   certificate_arn         = aws_acm_certificate.gitlab.arn
   validation_record_fqdns = [for record in aws_route53_record.gitlab-validation : record.fqdn]
 }
-
-# resource "aws_security_group_rule" "allow_gitlab_service" {
-#   count = var.service_subnet_count
-
-#   # this allows the gitlab runners to register with gitlab
-#   type              = "ingress"
-#   from_port         = 80
-#   to_port           = 80
-#   protocol          = "tcp"
-#   security_groups = [aws_nat_gateway.nat.*.XXX]
-#   security_group_id = aws_security_group.gitlab-ingress.id
-# }
-
-# resource "aws_security_group_rule" "allow_gitssh" {
-#   count = var.service_subnet_count
-
-#   # this allows the gitlab runners to check out code
-#   type              = "ingress"
-#   from_port         = 22
-#   to_port           = 22
-#   protocol          = "tcp"
-#   security_groups = [aws_nat_gateway.nat.*.XXX]
-#   security_group_id = aws_security_group.gitlab-ingress.id
-# }

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -226,33 +226,13 @@ resource "aws_security_group" "gitlab-ingress" {
     ipv6_cidr_blocks = data.aws_ip_ranges.ec2.ipv6_cidr_blocks
   }
 
-  # allow us to be able to get in
+  # allow kubernetes port-forward in to git-ssh
   ingress {
     from_port       = 22
     to_port         = 22
     protocol        = "tcp"
     security_groups = [aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id]
   }
-  # ingress {
-  #   from_port   = 22
-  #   to_port     = 22
-  #   protocol    = "tcp"
-  #   cidr_blocks = [var.vpc_cidr]
-  # }
-  # ingress {
-  #   from_port   = 22
-  #   to_port     = 22
-  #   protocol    = "tcp"
-  #   cidr_blocks = ["0.0.0.0/0"]
-  # }
-
-  # egress {
-  #   from_port        = 0
-  #   to_port          = 0
-  #   protocol         = "-1"
-  #   cidr_blocks      = ["0.0.0.0/0"]
-  #   ipv6_cidr_blocks = ["::/0"]
-  # }
 
   tags = {
     Name = "${var.cluster_name}-gitlab-ingress"

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -233,18 +233,26 @@ resource "aws_security_group" "gitlab-ingress" {
     protocol        = "tcp"
     security_groups = [aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id]
   }
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = [var.vpc_cidr]
-  }
-  ingress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+  # ingress {
+  #   from_port   = 22
+  #   to_port     = 22
+  #   protocol    = "tcp"
+  #   cidr_blocks = [var.vpc_cidr]
+  # }
+  # ingress {
+  #   from_port   = 22
+  #   to_port     = 22
+  #   protocol    = "tcp"
+  #   cidr_blocks = ["0.0.0.0/0"]
+  # }
+
+  # egress {
+  #   from_port        = 0
+  #   to_port          = 0
+  #   protocol         = "-1"
+  #   cidr_blocks      = ["0.0.0.0/0"]
+  #   ipv6_cidr_blocks = ["::/0"]
+  # }
 
   tags = {
     Name = "${var.cluster_name}-gitlab-ingress"

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -219,11 +219,31 @@ resource "aws_security_group" "gitlab-ingress" {
   # allow ec2 hosts from our region in
   # XXX eventually, once the networkfw gets put in, we will scrape the NAT gateways and put those in.
   ingress {
+    from_port        = 22
+    to_port          = 22
+    protocol         = "tcp"
+    cidr_blocks      = data.aws_ip_ranges.ec2.cidr_blocks
+    ipv6_cidr_blocks = data.aws_ip_ranges.ec2.ipv6_cidr_blocks
+  }
+
+  # allow us to be able to get in
+  ingress {
     from_port       = 22
     to_port         = 22
     protocol        = "tcp"
-    cidr_blocks      = data.aws_ip_ranges.ec2.cidr_blocks
-    ipv6_cidr_blocks = data.aws_ip_ranges.ec2.ipv6_cidr_blocks
+    security_groups = [aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id]
+  }
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.vpc_cidr]
+  }
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
   }
 
   tags = {

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -204,3 +204,19 @@ resource "aws_security_group" "gitlab-redis" {
     Name = "${var.cluster_name}-gitlab-redis"
   }
 }
+
+data "kubernetes_service" "gitlab-nginx-ingress-controller" {
+  depends_on = [aws_db_instance.gitlab]
+  metadata {
+    name      = "gitlab-nginx-ingress-controller"
+    namespace = "gitlab"
+  }
+}
+
+data "aws_lb" "gitlab-nginx-ingress-controller" {
+  name = data.kubernetes_service.gitlab-nginx-ingress-controller.status.0.load_balancer.0.ingress.0.hostname
+}
+
+output "gitlab-nginx-ingress-controller-arn" {
+  value       = data.aws_lb.gitlab-nginx-ingress-controller.arn
+}

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -5,6 +5,22 @@ resource "kubernetes_namespace" "gitlab" {
   }
 }
 
+data "kubernetes_service" "gitlab-nginx-ingress-controller" {
+  depends_on = [aws_db_instance.gitlab]
+  metadata {
+    name      = "gitlab-nginx-ingress-controller"
+    namespace = "gitlab"
+  }
+}
+
+resource "aws_route53_record" "gitssh" {
+  zone_id = data.aws_route53_zone.gitlab.zone_id
+  name    = "gitssh-${var.cluster_name}"
+  type    = "CNAME"
+  ttl     = "300"
+  records = [data.kubernetes_service.gitlab-nginx-ingress-controller.status.0.load_balancer.0.ingress.0.hostname]
+}
+
 # This configmap is where we can pass stuff into flux/helm from terraform
 resource "kubernetes_config_map" "terraform-gitlab-info" {
   depends_on = [kubernetes_namespace.gitlab]

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -38,6 +38,7 @@ resource "kubernetes_config_map" "terraform-gitlab-info" {
     "redishost"                = aws_elasticache_replication_group.gitlab.primary_endpoint_address
     "redisport"                = var.redis_port
     "ingress-security-groups"  = aws_security_group.gitlab-ingress.id
+    "fullhostname"             = "gitlab-${var.cluster_name}.${var.domain}"
   }
 }
 
@@ -250,13 +251,16 @@ resource "aws_security_group" "gitlab-ingress" {
     security_groups = [aws_eks_cluster.eks.vpc_config[0].cluster_security_group_id]
   }
 
-  # Allow the gitlab app to access itself over the ingress
-  ingress {
-    from_port       = 22
-    to_port         = 22
-    protocol        = "tcp"
-    security_groups = [aws_security_group.eks-cluster]
-  }
+  # # XXX allow in runners?
+  # # Their IP addresses are coming from the node external IP addresses, so can't
+  # # be allowed in with a security group
+  # ingress {
+  #   from_port       = 80
+  #   to_port         = 80
+  #   protocol        = "tcp"
+  #   # ec2 ranges work, but this is too big
+  #   cidr_blocks      = data.aws_ip_ranges.ec2.cidr_blocks
+  # }
 
   tags = {
     Name = "${var.cluster_name}-gitlab-ingress"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,3 +8,13 @@ output "teleport_url" {
   value       = "https://teleport-${var.cluster_name}.${var.domain}/"
   description = "The URL for teleport"
 }
+
+output "gitlab-privatelink-service_name" {
+  value = aws_vpc_endpoint_service.gitlab.service_name
+  description = "The service_name used by other VPCs to set up the gitlab privatelink"
+}
+
+output "gitlab-privatelink-service_type" {
+  value = aws_vpc_endpoint_service.gitlab.service_type
+  description = "The service_type used by other VPCs to set up the gitlab privatelink"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,11 +10,11 @@ output "teleport_url" {
 }
 
 output "gitlab-privatelink-service_name" {
-  value = aws_vpc_endpoint_service.gitlab.service_name
+  value       = aws_vpc_endpoint_service.gitlab.service_name
   description = "The service_name used by other VPCs to set up the gitlab privatelink"
 }
 
 output "gitlab-privatelink-service_type" {
-  value = aws_vpc_endpoint_service.gitlab.service_type
+  value       = aws_vpc_endpoint_service.gitlab.service_type
   description = "The service_type used by other VPCs to set up the gitlab privatelink"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -73,3 +73,9 @@ variable "rds_backup_window" {
 variable "redis_port" {
   default = 6379
 }
+
+variable "accountids" {
+  type        = list(string)
+  description = "list of AWS account ids that we should allow to find the gitlab privatelink service"
+  # export TF_VAR_accountids='["1234", "2345", "5678"]'
+}

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -29,20 +29,35 @@ resource "aws_subnet" "service" {
   }
 }
 
+# Public subnets to land loadbalancers/NAT/etc.
+resource "aws_subnet" "public_eks" {
+  count = var.service_subnet_count
+
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index + var.service_subnet_count)
+  vpc_id                  = aws_vpc.eks.id
+  map_public_ip_on_launch = true
+
+  tags = map(
+    "Name", "${var.cluster_name}-public-${count.index}",
+    "kubernetes.io/cluster/${var.cluster_name}", "shared",
+    "kubernetes.io/role/elb", "1",
+  )
+}
+
 # have the eks subnets come last so that we can add more later.
 resource "aws_subnet" "eks" {
   count = var.eks_subnet_count
 
   availability_zone       = data.aws_availability_zones.available.names[count.index]
-  cidr_block              = cidrsubnet(var.vpc_cidr, 6, count.index + var.service_subnet_count)
+  cidr_block              = cidrsubnet(var.vpc_cidr, 6, count.index + 2)
   vpc_id                  = aws_vpc.eks.id
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = false
 
   tags = map(
     "Name", "${var.cluster_name}-node-${count.index}",
     "kubernetes.io/cluster/${var.cluster_name}", "shared",
-    "kubernetes.io/role/elb", "1",
-    "kubernetes.io/role/internal-elb", ""
+    "kubernetes.io/role/internal-elb", "1"
   )
 }
 
@@ -54,7 +69,7 @@ resource "aws_internet_gateway" "eks" {
   }
 }
 
-resource "aws_route_table" "eks" {
+resource "aws_route_table" "public_eks" {
   vpc_id = aws_vpc.eks.id
 
   route {
@@ -67,9 +82,46 @@ resource "aws_route_table" "eks" {
   }
 }
 
-resource "aws_route_table_association" "eks" {
-  count = 2
+resource "aws_route_table_association" "public_eks" {
+  count = var.service_subnet_count
 
-  subnet_id      = aws_subnet.eks.*.id[count.index]
-  route_table_id = aws_route_table.eks.id
+  subnet_id      = aws_subnet.public_eks.*.id[count.index]
+  route_table_id = aws_route_table.public_eks.id
+}
+
+resource "aws_eip" "nat_gateway" {
+  count = var.service_subnet_count
+  vpc = true
+}
+
+resource "aws_nat_gateway" "nat" {
+  count = var.service_subnet_count
+
+  allocation_id = aws_eip.nat_gateway.*.id[count.index]
+  subnet_id     = aws_subnet.public_eks.*.id[count.index]
+
+  tags = {
+    Name = "${var.cluster_name} NAT ${count.index}"
+  }
+}
+
+resource "aws_route_table" "eks" {
+  count = var.eks_subnet_count
+
+  vpc_id = aws_vpc.eks.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat.*.id[count.index]
+  }
+
+  tags = {
+    Name = "${var.cluster_name} route to NAT ${count.index}"
+  }
+}
+
+resource "aws_route_table_association" "eks" {
+  count = var.eks_subnet_count
+
+  subnet_id     = aws_subnet.eks.*.id[count.index]
+  route_table_id = aws_route_table.eks.*.id[count.index]
 }

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -91,7 +91,7 @@ resource "aws_route_table_association" "public_eks" {
 
 resource "aws_eip" "nat_gateway" {
   count = var.service_subnet_count
-  vpc = true
+  vpc   = true
 }
 
 resource "aws_nat_gateway" "nat" {
@@ -122,6 +122,6 @@ resource "aws_route_table" "eks" {
 resource "aws_route_table_association" "eks" {
   count = var.eks_subnet_count
 
-  subnet_id     = aws_subnet.eks.*.id[count.index]
+  subnet_id      = aws_subnet.eks.*.id[count.index]
   route_table_id = aws_route_table.eks.*.id[count.index]
 }


### PR DESCRIPTION
This changes things so that we can do a "git pull" through VPC endpoints instead of the kinda clunky kubernetes port forwardy way.

It also:
* updates the documentation
* fixes a bug with the git-proxycommand.sh script
* locks down the ingress controller to be not accessible to the world, and makes it be an NLB so that it can be used by privatelink
* uses ACM for certs instead of letsencrypt, since it is no longer public
* Changes the network layout so that the nodes do not have external IPs and outbound traffic goes through NAT and should be ready for a network firewall to be jammed in.

Still todo:
- [x] get the endpoint wired up to an environment and fully tested
- [x] document the enable flag for identity-devops
- [x] change the branch back to main
