### PR TITLE
Add Network Firewall to deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ mechanisms.  Examples of this can be found in `terraform/gitlab.tf` and
 
 ## Setup
 
-The setup will only need to be run once per AWS account.  It sets up the s3 bucket
-and dynamodb stuff for remote state and locking and then goes on to do the deploy.
+The setup make sure that the s3 bucket
+and dynamodb stuff for remote state and locking are set up, then does
+the base deployment of the cluster and it's services.  After that is done,
+proceed to the Deploy step and execute that to complete the final resources.
 
 Run it like: `aws-vault exec sandbox-admin -- ./setup.sh gitlab-dev` where
 `gitlab-dev` is the name of your cluster.

--- a/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
+++ b/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: tspencer/networkfw
   secretRef:
     name: flux-system
   url: https://github.com/18F/identity-gitlab

--- a/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
+++ b/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: tspencer/networkfw
+    branch: main
   secretRef:
     name: flux-system
   url: https://github.com/18F/identity-gitlab

--- a/setup.sh
+++ b/setup.sh
@@ -76,5 +76,5 @@ terraform apply
 popd
 
 # Here we go!  This is where the magic happens.  :-)
-"$RUN_BASE/$SCRIPT_BASE/deploy.sh" "$1"
+TF_VAR_bootstrap=true "$RUN_BASE/$SCRIPT_BASE/deploy.sh" "$1"
 

--- a/terraform/eks-worker-nodes.tf
+++ b/terraform/eks-worker-nodes.tf
@@ -17,9 +17,9 @@ resource "aws_eks_node_group" "eks" {
   }
 
   scaling_config {
-    desired_size = 3
+    desired_size = 4
     max_size     = var.node_max_size
-    min_size     = 2
+    min_size     = 1
   }
 
   disk_size = var.node_disk_size

--- a/terraform/flux.tf
+++ b/terraform/flux.tf
@@ -4,6 +4,7 @@
 
 # Kubernetes
 resource "kubernetes_namespace" "flux_system" {
+  depends_on = [aws_eks_node_group.eks]
   metadata {
     name = "flux-system"
   }

--- a/terraform/logging.tf
+++ b/terraform/logging.tf
@@ -6,6 +6,7 @@
 #
 
 resource "kubernetes_namespace" "amazon-cloudwatch" {
+  depends_on = [aws_eks_node_group.eks]
   metadata {
     name = "amazon-cloudwatch"
   }

--- a/terraform/networkfw.tf
+++ b/terraform/networkfw.tf
@@ -1,5 +1,5 @@
 locals {
-  yaml_data = yamldecode(file("${path.module}/validdomain.yaml"))
+  yaml_data  = yamldecode(file("${path.module}/validdomain.yaml"))
   domainlist = concat(local.yaml_data.domainAllowList, [".${var.domain}"])
 }
 
@@ -91,7 +91,7 @@ data "aws_vpc_endpoint" "networkfw" {
   count      = var.subnet_count
   depends_on = [aws_networkfirewall_firewall.networkfw]
   vpc_id     = aws_vpc.eks.id
-  id         = [for x in aws_networkfirewall_firewall.networkfw.firewall_status.0.sync_states: x.attachment.0.endpoint_id if x.availability_zone == data.aws_availability_zones.available.names[count.index]][0]
+  id         = [for x in aws_networkfirewall_firewall.networkfw.firewall_status.0.sync_states : x.attachment.0.endpoint_id if x.availability_zone == data.aws_availability_zones.available.names[count.index]][0]
 }
 
 resource "aws_cloudwatch_log_group" "fw_log_group_alerts" {

--- a/terraform/networkfw.tf
+++ b/terraform/networkfw.tf
@@ -1,5 +1,6 @@
 locals {
   yaml_data = yamldecode(file("${path.module}/validdomain.yaml"))
+  domainlist = concat(local.yaml_data.domainAllowList, [".${var.domain}"])
 }
 
 resource "aws_networkfirewall_rule_group" "networkfw" {
@@ -12,7 +13,7 @@ resource "aws_networkfirewall_rule_group" "networkfw" {
       rules_source_list {
         generated_rules_type = "ALLOWLIST"
         target_types         = ["HTTP_HOST", "TLS_SNI"]
-        targets              = local.yaml_data.domainAllowList
+        targets              = local.domainlist
       }
     }
   }

--- a/terraform/networkfw.tf
+++ b/terraform/networkfw.tf
@@ -87,11 +87,10 @@ resource "aws_route_table_association" "networkfw" {
 }
 
 data "aws_vpc_endpoint" "networkfw" {
+  count      = var.subnet_count
   depends_on = [aws_networkfirewall_firewall.networkfw]
   vpc_id     = aws_vpc.eks.id
-  tags = {
-    Name = "Network Firewall for ${var.cluster_name}-gitlab"
-  }
+  id         = [for x in aws_networkfirewall_firewall.networkfw.firewall_status.0.sync_states: x.attachment.0.endpoint_id if x.availability_zone == data.aws_availability_zones.available.names[count.index]][0]
 }
 
 resource "aws_cloudwatch_log_group" "fw_log_group_alerts" {

--- a/terraform/networkfw.tf
+++ b/terraform/networkfw.tf
@@ -1,0 +1,122 @@
+locals {
+  yaml_data = yamldecode(file("${path.module}/validdomain.yaml"))
+}
+
+resource "aws_networkfirewall_rule_group" "networkfw" {
+  capacity    = 100
+  description = "Permits TLS traffic to selected endpoints"
+  name        = "${var.cluster_name}-gitlab-networkfw"
+  type        = "STATEFUL"
+  rule_group {
+    rules_source {
+      rules_source_list {
+        generated_rules_type = "ALLOWLIST"
+        target_types         = ["HTTP_HOST", "TLS_SNI"]
+        targets              = local.yaml_data.domainAllowList
+      }
+    }
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-gitlab permit TLS to selected endpoints"
+  }
+}
+
+resource "aws_networkfirewall_firewall_policy" "networkfw" {
+  name = "${var.cluster_name}-gitlab-networkfw"
+
+  firewall_policy {
+    stateless_default_actions          = ["aws:forward_to_sfe"]
+    stateless_fragment_default_actions = ["aws:forward_to_sfe"]
+    stateful_rule_group_reference {
+      resource_arn = aws_networkfirewall_rule_group.networkfw.arn
+    }
+  }
+
+  tags = {
+    Name = "${var.cluster_name}-gitlab Network firewall rules"
+  }
+}
+
+resource "aws_networkfirewall_firewall" "networkfw" {
+  name                = "${var.cluster_name}-gitlab-networkfw"
+  description         = "Network Firewall for ${var.cluster_name}-gitlab"
+  firewall_policy_arn = aws_networkfirewall_firewall_policy.networkfw.arn
+  vpc_id              = aws_vpc.eks.id
+
+  dynamic "subnet_mapping" {
+    for_each = aws_subnet.public_eks.*.id
+    content {
+      subnet_id = subnet_mapping.value
+    }
+  }
+
+  tags = {
+    Name = "Network Firewall for ${var.cluster_name}-gitlab"
+  }
+}
+
+resource "aws_subnet" "networkfw" {
+  count = var.subnet_count
+
+  vpc_id            = aws_vpc.eks.id
+  cidr_block        = cidrsubnet(var.fw_cidr, ceil(log(2, var.subnet_count)), count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+
+  tags = {
+    Name = "${var.cluster_name} firewall ${count.index}"
+  }
+}
+
+resource "aws_route_table" "networkfw" {
+  vpc_id = aws_vpc.eks.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.eks.id
+  }
+
+  tags = {
+    Name = "${var.cluster_name} gitlab networkfw"
+  }
+}
+
+resource "aws_route_table_association" "networkfw" {
+  count          = var.subnet_count
+  subnet_id      = aws_subnet.networkfw[count.index].id
+  route_table_id = aws_route_table.networkfw.id
+}
+
+data "aws_vpc_endpoint" "networkfw" {
+  depends_on = [aws_networkfirewall_firewall.networkfw]
+  vpc_id     = aws_vpc.eks.id
+  tags = {
+    Name = "Network Firewall for ${var.cluster_name}-gitlab"
+  }
+}
+
+resource "aws_cloudwatch_log_group" "fw_log_group_alerts" {
+  name = "/${var.cluster_name}-gitlab/networkfw_alerts"
+}
+resource "aws_cloudwatch_log_group" "fw_log_group_flows" {
+  name = "/${var.cluster_name}-gitlab/networkfw_flows"
+}
+
+resource "aws_networkfirewall_logging_configuration" "networkfw" {
+  firewall_arn = aws_networkfirewall_firewall.networkfw.arn
+  logging_configuration {
+    log_destination_config {
+      log_destination = {
+        logGroup = "/${var.cluster_name}-gitlab/networkfw_alerts"
+      }
+      log_destination_type = "CloudWatchLogs"
+      log_type             = "ALERT"
+    }
+    log_destination_config {
+      log_destination = {
+        logGroup = "/${var.cluster_name}-gitlab/networkfw_flows"
+      }
+      log_destination_type = "CloudWatchLogs"
+      log_type             = "FLOW"
+    }
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,11 +10,6 @@ output "teleport_url" {
 }
 
 output "gitlab-privatelink-service_name" {
-  value       = aws_vpc_endpoint_service.gitlab.service_name
+  value       = var.bootstrap ? "not defined: run terraform again without bootstrap set" : aws_vpc_endpoint_service.gitlab.0.service_name
   description = "The service_name used by other VPCs to set up the gitlab privatelink"
-}
-
-output "gitlab-privatelink-service_type" {
-  value       = aws_vpc_endpoint_service.gitlab.service_type
-  description = "The service_type used by other VPCs to set up the gitlab privatelink"
 }

--- a/terraform/ses.tf
+++ b/terraform/ses.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_user_policy" "gitlab-ses-email" {
-  name = "${var.cluster_name}-gitlab-ses-email"
-  user = aws_iam_user.gitlab-ses.name
+  name   = "${var.cluster_name}-gitlab-ses-email"
+  user   = aws_iam_user.gitlab-ses.name
   policy = data.aws_iam_policy_document.ses_email_user_policy.json
 }
 

--- a/terraform/teleport.tf
+++ b/terraform/teleport.tf
@@ -10,6 +10,8 @@
 #
 
 resource "kubernetes_namespace" "teleport" {
+  depends_on = [aws_eks_node_group.eks]
+
   metadata {
     name = "teleport"
     labels = {

--- a/terraform/validdomain.yaml
+++ b/terraform/validdomain.yaml
@@ -5,3 +5,10 @@ domainAllowList:
 - api.github.com
 - k8s.gcr.io
 - quay.io
+- public.ecr.aws
+- ghcr.io
+- registry-1.docker.io
+- .cloudfront.net
+- storage.googleapis.com
+- pkg-containers.githubusercontent.com
+- .teleport.cluster.local

--- a/terraform/validdomain.yaml
+++ b/terraform/validdomain.yaml
@@ -3,3 +3,4 @@ domainAllowList:
 - .amazonaws.com
 - github.com
 - api.github.com
+- k8s.gcr.io

--- a/terraform/validdomain.yaml
+++ b/terraform/validdomain.yaml
@@ -20,3 +20,4 @@ domainAllowList:
 - production.cloudflare.docker.com
 - github-releases.githubusercontent.com
 - gitlab.com
+- .api.letsencrypt.org

--- a/terraform/validdomain.yaml
+++ b/terraform/validdomain.yaml
@@ -12,3 +12,11 @@ domainAllowList:
 - storage.googleapis.com
 - pkg-containers.githubusercontent.com
 - .teleport.cluster.local
+- auth.docker.io
+- kubernetes.github.io
+- charts.gitlab.io
+- aws.github.io
+- registry.gitlab.com
+- production.cloudflare.docker.com
+- github-releases.githubusercontent.com
+- gitlab.com

--- a/terraform/validdomain.yaml
+++ b/terraform/validdomain.yaml
@@ -4,3 +4,4 @@ domainAllowList:
 - github.com
 - api.github.com
 - k8s.gcr.io
+- quay.io

--- a/terraform/validdomain.yaml
+++ b/terraform/validdomain.yaml
@@ -1,0 +1,5 @@
+# This is the list of domains which we are allowed to access from the gitlab environment
+domainAllowList:
+- .amazonaws.com
+- github.com
+- api.github.com

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -37,6 +37,11 @@ variable "fw_cidr" {
   description = "cidr block for firewalls"
 }
 
+variable "nat_cidr" {
+  default     = "10.0.6.0/23"
+  description = "cidr block for NAT"
+}
+
 variable "eks_cidr" {
   default     = "10.0.8.0/21"
   description = "private cidr block for EKS"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -99,3 +99,9 @@ variable "accountids" {
   description = "list of AWS account ids that we should allow to find the gitlab privatelink service"
   # export TF_VAR_accountids='["1234", "2345", "5678"]'
 }
+
+variable "bootstrap" {
+  description = "set this if you are bootstrapping this cluster for the first time.  There are things that need to get created later once the cluster is up that dependencies don't work on."
+  type        = bool
+  default     = false
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,14 +17,29 @@ variable "vpc_cidr" {
   description = "cidr block for VPC"
 }
 
-variable "eks_subnet_count" {
+variable "subnet_count" {
   default     = 2
-  description = "number of subnets used for EKS"
+  description = "number of subnets we use for each layer in this cluster"
 }
 
-variable "service_subnet_count" {
-  default     = 2
-  description = "number of subnets used for RDS and other services"
+variable "service_cidr" {
+  default     = "10.0.0.0/23"
+  description = "cidr block for services"
+}
+
+variable "public_cidr" {
+  default     = "10.0.2.0/23"
+  description = "cidr block for internet-facing services"
+}
+
+variable "fw_cidr" {
+  default     = "10.0.4.0/23"
+  description = "cidr block for firewalls"
+}
+
+variable "eks_cidr" {
+  default     = "10.0.8.0/21"
+  description = "private cidr block for EKS"
 }
 
 variable "nodetype" {

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -75,7 +75,7 @@ resource "aws_route_table" "public_eks" {
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = data.aws_vpc_endpoint.networkfw.id
+    gateway_id = data.aws_vpc_endpoint.networkfw[count.index].id
   }
 
   tags = {

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -75,7 +75,7 @@ resource "aws_route_table" "public_eks" {
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = data.aws_vpc_endpoint.networkfw[count.index].id
+    vpc_endpoint_id = data.aws_vpc_endpoint.networkfw[count.index].id
   }
 
   tags = {

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -7,7 +7,7 @@
 #
 
 resource "aws_vpc" "eks" {
-  cidr_block = var.vpc_cidr
+  cidr_block           = var.vpc_cidr
   enable_dns_support   = true
   enable_dns_hostnames = true
 
@@ -154,7 +154,7 @@ resource "aws_route_table" "nat" {
 
   vpc_id = aws_vpc.eks.id
   route {
-    cidr_block     = "0.0.0.0/0"
+    cidr_block      = "0.0.0.0/0"
     vpc_endpoint_id = data.aws_vpc_endpoint.networkfw[count.index].id
   }
 


### PR DESCRIPTION
This restructures the system so that the networkfw is filtering all outbound requests, giving us control over what our systems can talk to.

It also restructures the network stuff so that it's not trying to be so damn clever with cidrsubnet.  It turned out to be too confusing, so we are now just setting the subnets explicitly.  If we need more address space, we can either make the subnets bigger, or we can (probably better) add an eks2 set of subnets with another /22 in it like the eks subnet is set up now.
