### PR TITLE
Use separate hostnames for GitHub web frontend and runner endpoint.

### DIFF
--- a/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
+++ b/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: akrito/fix_github_and_runners
+    branch: main
   secretRef:
     name: flux-system
   url: https://github.com/18F/identity-gitlab

--- a/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
+++ b/clusters/gitlab-cluster/flux-system/gotk-sync.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: akrito/fix_github_and_runners
   secretRef:
     name: flux-system
   url: https://github.com/18F/identity-gitlab

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -26,6 +26,8 @@ spec:
         namespace: flux-system
       interval: 1m
   values:
+    gitlab-runner:
+      gitlabUrl: http://gitlab-webservice-default
     nginx-ingress:
       controller:
         scope:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -138,7 +138,7 @@ spec:
       targetPath: global.hosts.gitlab.hostnameOverride
     - kind: ConfigMap
       name: terraform-gitlab-info
-      valuesKey: fullhostname
+      valuesKey: ci_server_url
       targetPath: gitlab-runner.gitlabUrl
     - kind: ConfigMap
       name: terraform-gitlab-info

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -26,8 +26,6 @@ spec:
         namespace: flux-system
       interval: 1m
   values:
-    gitlab-runner:
-      gitlabUrl: http://gitlab-webservice-default
     nginx-ingress:
       controller:
         scope:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -26,8 +26,6 @@ spec:
         namespace: flux-system
       interval: 1m
   values:
-    gitlab-runner:
-      gitlabUrl: http://gitlab-webservice-default
     nginx-ingress:
       controller:
         scope:
@@ -138,6 +136,10 @@ spec:
       name: terraform-gitlab-info
       valuesKey: fullhostname
       targetPath: global.hosts.gitlab.hostnameOverride
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: fullhostname
+      targetPath: gitlab-runner.gitlabUrl
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: certmanager-issuer-email

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -130,7 +130,7 @@ spec:
       targetPath: global.hosts.hostSuffix
     - kind: ConfigMap
       name: terraform-gitlab-info
-      valuesKey: fullhostname
+      valuesKey: gitlab_name
       targetPath: global.hosts.gitlab.name
     - kind: ConfigMap
       name: terraform-gitlab-info

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -23,7 +23,8 @@ resource "kubernetes_config_map" "terraform-gitlab-info" {
     "redishost"                = aws_elasticache_replication_group.gitlab.primary_endpoint_address
     "redisport"                = var.redis_port
     "ingress-security-groups"  = aws_security_group.gitlab-ingress.id
-    "fullhostname"             = "teleport-${var.cluster_name}.${var.domain}"
+    "gitlab_name"              = "gitlab.teleport-${var.cluster_name}.${var.domain}"
+    "fullhostname"             = "gitlab-${var.cluster_name}.${var.domain}"
     "cert-arn"                 = aws_acm_certificate.gitlab.arn
     "email-from"               = "gitlab@${var.cluster_name}.${var.domain}"
     "smtp-endpoint"            = "email-smtp.${var.region}.amazonaws.com"

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -25,6 +25,7 @@ resource "kubernetes_config_map" "terraform-gitlab-info" {
     "ingress-security-groups"  = aws_security_group.gitlab-ingress.id
     "gitlab_name"              = "gitlab.teleport-${var.cluster_name}.${var.domain}"
     "fullhostname"             = "gitlab-${var.cluster_name}.${var.domain}"
+    "ci_server_url"            = "https://gitlab-${var.cluster_name}.${var.domain}"
     "cert-arn"                 = aws_acm_certificate.gitlab.arn
     "email-from"               = "gitlab@${var.cluster_name}.${var.domain}"
     "smtp-endpoint"            = "email-smtp.${var.region}.amazonaws.com"


### PR DESCRIPTION
This separates the values used for the gitlab web frontend domain name and the runner endpoint.