### PR TITLE
Override CLONE_URL env var

### DIFF
--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -142,6 +142,10 @@ spec:
       targetPath: gitlab-runner.gitlabUrl
     - kind: ConfigMap
       name: terraform-gitlab-info
+      valuesKey: ci_server_url
+      targetPath: gitlab-runner.runners.cloneUrl
+    - kind: ConfigMap
+      name: terraform-gitlab-info
       valuesKey: certmanager-issuer-email
       targetPath: certmanager-issuer.email
     - kind: ConfigMap


### PR DESCRIPTION
Longer term, we'll want to revisit this and override via the method in https://docs.gitlab.com/runner/configuration/advanced-configuration.html