### PR TITLE
map has been replaced with tomap, version constraints deprecated

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -3,8 +3,7 @@
 #
 
 provider "aws" {
-  region  = var.region
-  version = "~> 3.35"
+  region = var.region
 }
 
 terraform {
@@ -32,7 +31,6 @@ data "aws_caller_identity" "current" {}
 
 # This is the main provider
 provider "kubernetes" {
-  version                = "~> 2.0.3"
   host                   = aws_eks_cluster.eks.endpoint
   cluster_ca_certificate = base64decode(aws_eks_cluster.eks.certificate_authority[0].data)
   exec {
@@ -45,7 +43,6 @@ provider "kubernetes" {
 
 # This is so we can install helm stuff
 provider "helm" {
-  version = "~> 2.1.0"
   kubernetes {
     host                   = aws_eks_cluster.eks.endpoint
     cluster_ca_certificate = base64decode(aws_eks_cluster.eks.certificate_authority[0].data)
@@ -59,7 +56,6 @@ provider "helm" {
 }
 
 provider "kubectl" {
-  version          = ">= 1.10.0"
   load_config_file = false
   # apply_retry_count      = 15
   host                   = aws_eks_cluster.eks.endpoint

--- a/terraform/vpc.tf
+++ b/terraform/vpc.tf
@@ -11,10 +11,10 @@ resource "aws_vpc" "eks" {
   enable_dns_support   = true
   enable_dns_hostnames = true
 
-  tags = map(
-    "Name", "${var.cluster_name}-vpc",
-    "kubernetes.io/cluster/${var.cluster_name}", "shared",
-  )
+  tags = tomap({
+    "Name"                                      = "${var.cluster_name}-vpc",
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared",
+  })
 }
 
 # Public subnets to land NAT.
@@ -26,9 +26,9 @@ resource "aws_subnet" "nat" {
   vpc_id                  = aws_vpc.eks.id
   map_public_ip_on_launch = true
 
-  tags = map(
-    "Name", "${var.cluster_name}-nat-${count.index}",
-  )
+  tags = tomap({
+    "Name" = "${var.cluster_name}-nat-${count.index}",
+  })
 }
 
 # Public subnets to land loadbalancers/etc.
@@ -40,11 +40,11 @@ resource "aws_subnet" "public_eks" {
   vpc_id                  = aws_vpc.eks.id
   map_public_ip_on_launch = true
 
-  tags = map(
-    "Name", "${var.cluster_name}-public-${count.index}",
-    "kubernetes.io/cluster/${var.cluster_name}", "shared",
-    "kubernetes.io/role/elb", "1",
-  )
+  tags = tomap({
+    "Name"                                      = "${var.cluster_name}-public-${count.index}",
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared",
+    "kubernetes.io/role/elb"                    = "1",
+  })
 }
 
 # eks subnets
@@ -56,11 +56,11 @@ resource "aws_subnet" "eks" {
   vpc_id                  = aws_vpc.eks.id
   map_public_ip_on_launch = false
 
-  tags = map(
-    "Name", "${var.cluster_name}-node-${count.index}",
-    "kubernetes.io/cluster/${var.cluster_name}", "shared",
-    "kubernetes.io/role/internal-elb", "1"
-  )
+  tags = tomap({
+    "Name"                                      = "${var.cluster_name}-node-${count.index}",
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared",
+    "kubernetes.io/role/internal-elb"           = "1"
+  })
 }
 
 # db/service networks


### PR DESCRIPTION
In order to stay current with upstream, `terraform` v0.12, v0.13 and v1.0 contain changes to `tomap` and provider version constraints.