### PR TITLE
aws-load-balancer-internal requires true or false and been deprecated

### DIFF
--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -57,7 +57,6 @@ spec:
             https: http
           annotations:
             service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: Name=gitlab-nginx,class=nginx,role=test,vpc=test
-            service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
             service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
             service.beta.kubernetes.io/aws-load-balancer-backend-protocol: "tcp"
             service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"


### PR DESCRIPTION
_"service.beta.kubernetes.io/aws-load-balancer-internal specifies whether the NLB will be internet-facing or internal."_ and takes a `true` or `false` value, defaulting to `false`: https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/service/annotations/

Replaced by `service.beta.kubernetes.io/aws-load-balancer-scheme` which defaults to `internal`