### PR TITLE
fixes the ECR test so that it doesn't crash every other run

### DIFF
--- a/tests/gitlab_test.go
+++ b/tests/gitlab_test.go
@@ -201,6 +201,7 @@ func TestGitlabRunnerRoleECR(t *testing.T) {
 	aws.CreateECRRepo(t, region, reponame)
 	// Clean up afterwards
 	os.Unsetenv("TERRATEST_IAM_ROLE")
+	repo, err = aws.GetECRRepoE(t, region, reponame)
 	aws.DeleteECRRepo(t, region, repo)
 }
 


### PR DESCRIPTION
Apparently, if you delete a repo that has already been deleted, it causes a segv.