### PR TITLE
Add cloudwatch alert for runners

### DIFF
--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -35,8 +35,6 @@ spec:
     gitlab-runner:
       runners:
         serviceAccountName: gitlab-gitlab-runner
-        env:
-          CLUSTER_NAME: 
       rbac:
         create: true
         resources: ["pods", "pods/exec", "secrets"]

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -35,6 +35,8 @@ spec:
     gitlab-runner:
       runners:
         serviceAccountName: gitlab-gitlab-runner
+        env:
+          CLUSTER_NAME: 
       rbac:
         create: true
         resources: ["pods", "pods/exec", "secrets"]
@@ -133,6 +135,10 @@ spec:
       name: terraform-gitlab-info
       valuesKey: cluster_name
       targetPath: clusterName
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: cluster_name
+      targetPath: gitlab-runner.runners.env.CLUSTER_NAME
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: domain

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -1,14 +1,15 @@
 # CloudWatch Alarms
 resource "aws_cloudwatch_metric_alarm" "runner_alarm" {
-  alarm_name                = "GitLab Runner Unhealthy"
+  alarm_name                = "${var.cluster_name} GitLab Runner Unhealthy"
   comparison_operator       = "LessThanThreshold"
   evaluation_periods        = "1"
   metric_name               = "ScheduledPipelineSuccess"
   namespace                 = "${var.cluster_name}/gitlab"
   period                    = "900"
-  statistic                 = "SampleCount"
+  statistic                 = "Sum"
   threshold                 = "1"
   alarm_description         = "This Alarm is executed if no runner has successfully completed in the last 15m."
+  treat_missing_data        = "breaching"
   insufficient_data_actions = []
   alarm_actions             = [
     "arn:aws:sns:${var.region}:${data.aws_caller_identity.current.account_id}:slack-otherevents",

--- a/terraform/alarms.tf
+++ b/terraform/alarms.tf
@@ -1,0 +1,16 @@
+# CloudWatch Alarms
+resource "aws_cloudwatch_metric_alarm" "runner_alarm" {
+  alarm_name                = "GitLab Runner Unhealthy"
+  comparison_operator       = "LessThanThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "ScheduledPipelineSuccess"
+  namespace                 = "${var.cluster_name}/gitlab"
+  period                    = "900"
+  statistic                 = "SampleCount"
+  threshold                 = "1"
+  alarm_description         = "This Alarm is executed if no runner has successfully completed in the last 15m."
+  insufficient_data_actions = []
+  alarm_actions             = [
+    "arn:aws:sns:${var.region}:${data.aws_caller_identity.current.account_id}:slack-otherevents",
+  ]
+}


### PR DESCRIPTION
Currently, the pipeline is in the Monitoring project. A separate PR will pull it into identity-gitlab, after that repo is also hosted on GitLab