### PR TITLE
Sync from GitHub to GitLab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,3 +5,15 @@ write_metrics:
   script:
     - cd monitoring
     - go run metrics.go --cluster=$CLUSTER_NAME
+
+sync_from_github:
+  image: alpine/git:latest
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - cd .git
+    - git config --bool core.bare true
+    - git remote add --mirror=fetch github https://github.com/18F/identity-gitlab.git
+    - git remote add --mirror=push gitlab https://identity-servers:"$gitlab_identity_servers_access_key"@gitlab-"$CLUSTER_NAME".gitlab.identitysandbox.gov/lg/identity-gitlab.git
+    - git fetch github --prune --prune-tags
+    - git push gitlab --prune

--- a/docs/Sync.md
+++ b/docs/Sync.md
@@ -1,0 +1,18 @@
+# GitHub -> GitLab sync
+
+This repo contains a pipeline definition that syncs itself from GitHub when run
+by a GitLab schedule.
+
+## Authentication
+
+`identity-gitlab` is a public GitHub repo, so no authentication is needed to
+pull from there.  In order to push to GitLab, there is an `identity-servers`
+GitLab user that is allowed to push to protected branches.
+
+This user's password is in AWS Secrets Manager in the `login-tooling` account,
+in the `gitlab/identity-servers/password.txt` secret.
+
+An GitLab-instance-level access key for this user,
+`gitlab_identity_servers_access_key`, is defined at
+https://gitlab.teleport-$CLUSTER.gitlab.identitysandbox.gov/admin/application_settings/ci_cd -
+only jobs running on protected branches have access to this key.


### PR DESCRIPTION
Currently I'm using the secrets manager inside GitLab. The GitLab secret manager has the advantage of limiting access to jobs running on protected branches, i.e. jobs running on dev branches can't see the secret.
Since the runner has an IAM role, we could also keep the secret in AWS Secrets Manager, and allow the role access to it, but that would allow dev branches to see the secret and use it to force push to `main` without review.