### PR TITLE
Add dev domains to be able to run smoke tests

### DIFF
--- a/terraform/validdomain.yaml
+++ b/terraform/validdomain.yaml
@@ -34,3 +34,7 @@ domainAllowList:
 - deb.nodesource.com
 - deb.debian.org
 - security.debian.org
+# Smoke tests
+- idp.dev.identitysandbox.gov
+- dev-identity-oidc-sinatra.app.cloud.gov
+- dev-identity-saml-sinatra.app.cloud.gov


### PR DESCRIPTION
The smoke tests communicate with these domains to run feature specs on a deployed environment