### PR TITLE
Upgrade to gitlab 4.12.8 helm chart

### DIFF
--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -32,6 +32,10 @@ spec:
         serviceAccount:
           create: true
           enabled: true
+      webservice:
+        serviceAccount:
+          create: true
+          enabled: true
       task-runner:
         enabled: true
         backups:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -50,7 +50,7 @@ spec:
           secretName: gitlab-storage
       rbac:
         create: true
-        resources: ["pods", "pods/exec", "secrets"]
+        resources: ["pods", "pods/exec", "secrets", "configmaps", "pods/attach"]
         verbs: ["get", "list", "watch", "create", "patch", "delete"]
     nginx-ingress:
       controller:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -268,13 +268,11 @@ spec:
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: storage-iam-role
-      # targetPath: gitlab.webservice.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
-      targetPath: gitlab.webservice.annotations.eks\.amazonaws\.com/role-arn
+      targetPath: gitlab.webservice.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: storage-iam-role
-      # targetPath: gitlab.sidekiq.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
-      targetPath: gitlab.sidekiq.annotations.eks\.amazonaws\.com/role-arn
+      targetPath: gitlab.sidekiq.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: storage-iam-role

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -263,6 +263,10 @@ spec:
       targetPath: global.smtp.user_name
     - kind: ConfigMap
       name: terraform-gitlab-info
+      valuesKey: storage-iam-role
+      targetPath: global.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+    - kind: ConfigMap
+      name: terraform-gitlab-info
       valuesKey: runner-iam-role
       targetPath: gitlab-runner.rbac.serviceAccountAnnotations.eks\.amazonaws\.com/role-arn
     - kind: ConfigMap

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -268,11 +268,13 @@ spec:
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: storage-iam-role
-      targetPath: gitlab.webservice.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+      # targetPath: gitlab.webservice.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+      targetPath: gitlab.webservice.annotations.eks\.amazonaws\.com/role-arn
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: storage-iam-role
-      targetPath: gitlab.sidekiq.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+      # targetPath: gitlab.sidekiq.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+      targetPath: gitlab.sidekiq.annotations.eks\.amazonaws\.com/role-arn
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: storage-iam-role

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -272,7 +272,15 @@ spec:
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: storage-iam-role
+      targetPath: gitlab.webservice.annotations.eks\.amazonaws\.com/role-arn
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: storage-iam-role
       targetPath: gitlab.sidekiq.serviceAccount.annotations.eks\.amazonaws\.com/role-arn
+    - kind: ConfigMap
+      name: terraform-gitlab-info
+      valuesKey: storage-iam-role
+      targetPath: gitlab.sidekiq.annotations.eks\.amazonaws\.com/role-arn
     - kind: ConfigMap
       name: terraform-gitlab-info
       valuesKey: storage-iam-role

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -20,7 +20,7 @@ spec:
   chart:
     spec:
       chart: gitlab
-      version: "4.11.4"
+      version: "4.12.8"
       sourceRef:
         kind: HelmRepository
         name: gitlab

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -28,6 +28,10 @@ spec:
       interval: 1m
   values:
     gitlab:
+      sidekiq:
+        serviceAccount:
+          create: true
+          enabled: true
       task-runner:
         enabled: true
         backups:

--- a/terraform/gitlab.tf
+++ b/terraform/gitlab.tf
@@ -485,7 +485,9 @@ resource "aws_iam_role" "storage-iam-role" {
         "ForAnyValue:StringEquals": {
           "${aws_iam_openid_connect_provider.eks.url}:sub": [
             "system:serviceaccount:gitlab:gitlab-gitlab-runner",
-            "system:serviceaccount:gitlab:gitlab-task-runner"
+            "system:serviceaccount:gitlab:gitlab-task-runner",
+            "system:serviceaccount:gitlab:gitlab-sidekiq",
+            "system:serviceaccount:gitlab:gitlab-webservice"
           ]
         }
       }


### PR DESCRIPTION
We need to upgrade to this before we can go to 5.0, which is the next step to go to 5.1, which will bring us gitlab 14.

There were some changes with how roles worked, apparently.  Either that, or stuff was broken, and I just didn't see it before.