### PR TITLE
Disable registry feature in all components

### DIFF
--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -114,7 +114,7 @@ spec:
     certmanager:
       install: false
     registry:
-      # enabled: false
+      enabled: false
     global:
       minio:
         enabled: false

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -114,7 +114,7 @@ spec:
     certmanager:
       install: false
     registry:
-      enabled: false
+      # enabled: false
     global:
       minio:
         enabled: false

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -188,6 +188,8 @@ spec:
           blockAutoCreatedUsers: false
           providers:
             - secret: gitlab-github-auth
+        defaultProjectsFeatures:
+          containerRegistry: false
     postgresql:
       install: false
     redis:

--- a/clusters/gitlab-cluster/gitlab/gitlab.yaml
+++ b/clusters/gitlab-cluster/gitlab/gitlab.yaml
@@ -29,15 +29,21 @@ spec:
   values:
     gitlab:
       sidekiq:
+        registry:
+          enabled: false
         serviceAccount:
           create: true
           enabled: true
       webservice:
+        registry:
+          enabled: false
         serviceAccount:
           create: true
           enabled: true
       task-runner:
         enabled: true
+        registry:
+          enabled: false
         backups:
           cron:
             enabled: true


### PR DESCRIPTION
Disabling the registry in the Helm chart doesn't trickle-down into the components. Project deletion wasn't working because workers were trying to contact the non-existent registry.

- https://gitlab.com/gitlab-org/charts/gitlab/-/issues/1455 (disabling registry prevents project deletion)
- https://gitlab.com/gitlab-org/charts/gitlab/-/issues/1456 (projects have registry feature enabled even when registry is disabled)
- https://gitlab.com/gitlab-org/charts/gitlab/-/issues/2464 (webservice, sidekiq and task-runner have registry feature enabled even when registry is disabled)
