### PR TITLE
Mirror images over to our ECR

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -35,3 +35,4 @@ sync_images_to_ecr:
     - # also:  the REGION, CI_REGISTRY_PASSWORD, CI_REGISTRY, CI_REGISTRY_USER environment variables must be set
     - ./sync-repo.sh alpine/git latest
     - ./sync-repo.sh library/golang latest
+    - ./sync-repo.sh library/alpine latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 write_metrics:
-  image: golang:latest
+  image: mirror.gcr.io/library/golang:latest
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
@@ -7,7 +7,7 @@ write_metrics:
     - go run metrics.go --cluster=$CLUSTER_NAME
 
 sync_from_github:
-  image: alpine/git:latest
+  image: mirror.gcr.io/alpine/git:latest
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule"
   script:
@@ -17,3 +17,21 @@ sync_from_github:
     - git remote add --mirror=push gitlab https://identity-servers:"$gitlab_identity_servers_access_key"@gitlab-"$CLUSTER_NAME".gitlab.identitysandbox.gov/lg/identity-gitlab.git
     - git fetch github --prune --prune-tags
     - git push gitlab --prune
+
+sync_images_to_ecr:
+  image: mirror.gcr.io/library/alpine
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "schedule"
+  script:
+    - apk add aws-cli
+    - apk add skopeo
+    - aws ecr get-login-password >/dev/null # This is to make sure we bail if we can't actually do this job
+    - export CI_REGISTRY_PASSWORD="$(aws ecr get-login-password)"
+    - export CI_REGISTRY_USER=AWS
+    - export CI_REGISTRY="$(aws sts get-caller-identity --query Account --output text).dkr.ecr.$REGION.amazonaws.com"
+    - # usage:   ./sync-repo.sh <repo> <tag> [<registry>]
+    - # example: ./sync-repo.sh alpine/git latest
+    - # example: ./sync-repo.sh amazonlinux/amazonlinux latest public.ecr.aws
+    - # also:  the REGION, CI_REGISTRY_PASSWORD, CI_REGISTRY, CI_REGISTRY_USER environment variables must be set
+    - ./sync-repo.sh alpine/git latest
+    - ./sync-repo.sh library/golang latest

--- a/sync-repo.sh
+++ b/sync-repo.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+#
+# This syncs a repo from the location specified to our local ECR repo.
+# The default is to get it from the Google docker hub mirror,
+# but if you supply two args, it gets it from the specified registry.
+
+usage() {
+	echo "usage:   $0 <repo> <tag> [<registry>]"
+	echo "example: $0 alpine/git latest"
+	echo "example: $0 amazonlinux/amazonlinux latest public.ecr.aws"
+	echo "also:  the REGION, CI_REGISTRY_PASSWORD, CI_REGISTRY, CI_REGISTRY_USER environment variables must be set"
+	exit 1
+}
+
+if [ -z "$1" ] ; then
+	echo "missing repo"
+	usage
+else
+	REPO="$1"
+fi
+if [ -z "$2" ] ; then
+	echo "missing tag"
+	usage
+else
+	TAG="$2"
+fi
+if [ -z "$3" ] ; then
+	REGISTRY="mirror.gcr.io"
+else
+	REGISTRY="$3"
+fi
+
+if [ -z "$REGION" ] ; then
+	echo "missing REGION variable"
+	usage
+fi
+if [ -z "$CI_REGISTRY_PASSWORD" ] ; then
+	echo "missing CI_REGISTRY_PASSWORD variable"
+	usage
+fi
+if [ -z "$CI_REGISTRY" ] ; then
+	echo "missing CI_REGISTRY variable"
+	usage
+fi
+if [ -z "$CI_REGISTRY_USER" ] ; then
+	echo "missing CI_REGISTRY_USER variable"
+	usage
+fi
+
+# AWS won't let you push to a repo unless you've created it
+aws ecr create-repository --repository-name "$REPO" --region "$REGION" --image-scanning-configuration scanOnPush=true --encryption-configuration encryptionType=AES256 || true
+
+skopeo copy -a --dest-creds "$CI_REGISTRY_USER:$CI_REGISTRY_PASSWORD" "docker://$REGISTRY/$REPO:$TAG" "docker://$CI_REGISTRY/$REPO:$TAG"

--- a/terraform/validdomain.yaml
+++ b/terraform/validdomain.yaml
@@ -6,6 +6,7 @@ domainAllowList:
 - k8s.gcr.io
 - quay.io
 - public.ecr.aws
+- mirror.gcr.io
 - ghcr.io
 - registry-1.docker.io
 - .cloudfront.net
@@ -42,3 +43,5 @@ domainAllowList:
 - dev-identity-saml-sinatra.app.cloud.gov
 - clients2.google.com
 - imap.gmail.com
+# so we can install packages for alpine
+- dl-cdn.alpinelinux.org

--- a/terraform/validdomain.yaml
+++ b/terraform/validdomain.yaml
@@ -6,7 +6,6 @@ domainAllowList:
 - k8s.gcr.io
 - quay.io
 - public.ecr.aws
-- mirror.gcr.io
 - ghcr.io
 - registry-1.docker.io
 - .cloudfront.net


### PR DESCRIPTION
This is the first step to being able to use our own ECR for our images.  This mirrors a couple of images so that they can get scanned and everything.

More work is needed to give a good example with kustomize for replacing images so that we pull them from our ECR.  There will be another PR for that.
