### PR TITLE
Add identity-fake-server sinatra app

### DIFF
--- a/clusters/gitlab-cluster/identity-fake-server/README.md
+++ b/clusters/gitlab-cluster/identity-fake-server/README.md
@@ -1,0 +1,9 @@
+# identity-fake-server
+
+This sets up https://github.com/18F/identity-fake-server.
+
+To access it, do this:
+```
+kubectl port-forward service/identity-fake-server 5555:5555 -n identity-fake-server
+```
+and then go to http://localhost:5555/

--- a/clusters/gitlab-cluster/identity-fake-server/identity-fake-server.yaml
+++ b/clusters/gitlab-cluster/identity-fake-server/identity-fake-server.yaml
@@ -5,3 +5,61 @@ metadata:
   name: identity-fake-server
 
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: identity-fake-server
+  namespace: identity-fake-server
+spec:
+  selector:
+    matchLabels:
+      app: identity-fake-server
+  template:
+    metadata:
+      labels:
+        app: identity-fake-server
+        service: identity-fake-server
+    spec:
+      containers:
+      - name: identity-fake-server
+        image: logindotgov/identity-fake-server:latest
+        ports:
+        - containerPort: 5555
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  labels:
+    k8s-app: identity-fake-server
+  name: identity-fake-server
+  namespace: identity-fake-server
+spec:
+  ports:
+    - port: 5555
+      targetPort: 5555
+  selector:
+    k8s-app: identity-fake-server
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: identity-fake-server
+  namespace: identity-fake-server
+  annotations:
+    # use the shared ingress-nginx
+    kubernetes.io/ingress.class: "nginx"
+spec:
+  rules:
+  - host: identity-fake-server.grevi.ch
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: identity-fake-server
+            port:
+              number: 5555
+---

--- a/clusters/gitlab-cluster/identity-fake-server/identity-fake-server.yaml
+++ b/clusters/gitlab-cluster/identity-fake-server/identity-fake-server.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: identity-fake-server
+
+---

--- a/clusters/gitlab-cluster/identity-fake-server/identity-fake-server.yaml
+++ b/clusters/gitlab-cluster/identity-fake-server/identity-fake-server.yaml
@@ -10,15 +10,16 @@ kind: Deployment
 metadata:
   name: identity-fake-server
   namespace: identity-fake-server
+  labels:
+    k8s-app: identity-fake-server
 spec:
   selector:
     matchLabels:
-      app: identity-fake-server
+      k8s-app: identity-fake-server
   template:
     metadata:
       labels:
-        app: identity-fake-server
-        service: identity-fake-server
+        k8s-app: identity-fake-server
     spec:
       containers:
       - name: identity-fake-server
@@ -38,6 +39,7 @@ spec:
   ports:
     - port: 5555
       targetPort: 5555
+      protocol: TCP
   selector:
     k8s-app: identity-fake-server
 

--- a/clusters/gitlab-cluster/identity-fake-server/kustomization.yaml
+++ b/clusters/gitlab-cluster/identity-fake-server/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- identity-fake-server.yaml

--- a/clusters/gitlab-cluster/kustomization.yaml
+++ b/clusters/gitlab-cluster/kustomization.yaml
@@ -11,3 +11,4 @@ resources:
 - ./metrics-server/
 - ./dashboard/
 - ./aws-vpc-cni/
+- ./identity-fake-server/


### PR DESCRIPTION
I thought this would be a nice way to dovetail a need to run our mock proofer app at load and also get to know login.gov's EKS stack more. The goal is to get https://github.com/18F/identity-fake-server deployed and able to scale out.